### PR TITLE
Adding Bitwarden passwordless functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ __pycache__/
 src/streamlit_passwordless/bitwarden_passwordless/frontend/node_modules/
 src/streamlit_passwordless/bitwarden_passwordless/frontend/build/
 
+# Custom
+.streamlit
+temp/
+
 # C extensions
 *.so
 

--- a/conda/streamlit_passwordless_dev.yml
+++ b/conda/streamlit_passwordless_dev.yml
@@ -4,8 +4,10 @@ channels:
   - conda-forge
 dependencies:
   # Run
+  - marshmallow >=3.0
   - pydantic >=1.10
   - python >=3.11
+  - requests >=2.27
   - streamlit >=1.24
 
   # Test
@@ -21,3 +23,8 @@ dependencies:
   - flake8 >=4.0
   - mypy >=0.910
   - python-dotenv >=0.21
+
+  # PyPI - Run
+  - pip >=23.0
+  - pip:
+      - passwordless >=0.1

--- a/conda/streamlit_passwordless_dev.yml
+++ b/conda/streamlit_passwordless_dev.yml
@@ -21,6 +21,7 @@ dependencies:
   # Tools
   - black >=22.0
   - flake8 >=4.0
+  - isort >=5.0
   - mypy >=0.910
   - python-dotenv >=0.21
 

--- a/conda/streamlit_passwordless_dev_linux-64_lock.yml
+++ b/conda/streamlit_passwordless_dev_linux-64_lock.yml
@@ -116,6 +116,7 @@ dependencies:
   - lz4-c=1.9.4=h6a678d5_0
   - markdown-it-py=2.2.0=py311h06a4308_1
   - markupsafe=2.1.1=py311h5eee18b_0
+  - marshmallow=3.19.0=py311h06a4308_0
   - matplotlib-inline=0.1.6=py311h06a4308_0
   - mccabe=0.7.0=pyhd3eb1b0_0
   - mdurl=0.1.0=py311h06a4308_0
@@ -227,3 +228,5 @@ dependencies:
   - zipp=3.11.0=py311h06a4308_0
   - zlib=1.2.13=h5eee18b_0
   - zstd=1.5.5=hc292b87_0
+  - pip:
+      - passwordless==0.1.1

--- a/conda/streamlit_passwordless_dev_linux-64_lock.yml
+++ b/conda/streamlit_passwordless_dev_linux-64_lock.yml
@@ -64,6 +64,7 @@ dependencies:
   - ipython=8.15.0=py311h06a4308_0
   - ipython_genutils=0.2.0=pyhd3eb1b0_1
   - ipywidgets=7.6.5=pyhd3eb1b0_2
+  - isort=5.9.3=pyhd3eb1b0_0
   - jaraco.classes=3.2.1=pyhd3eb1b0_0
   - jedi=0.18.1=py311h06a4308_1
   - jeepney=0.7.1=pyhd3eb1b0_0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,11 @@ target-version = ["py311"]
 skip-string-normalization = true
 
 
+[tool.isort]
+profile = "black"
+line_length = 100
+
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-rsxX --showlocals --tb=short --strict-markers"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dynamic = ["version"]
 
 dependencies = [
     "streamlit >= 1.24",
+    "passwordless >= 0.1",
 ]
 
 
@@ -67,5 +68,5 @@ warn_return_any = true
 warn_unreachable = true
 
 [[tool.mypy.overrides]]
-module = ["streamlit_passwordless.*"]
+module = ["streamlit_passwordless.*", "passwordless.*"]
 ignore_missing_imports = true

--- a/src/streamlit_passwordless/bitwarden_passwordless/backend.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/backend.py
@@ -1,0 +1,89 @@
+r"""The functions and models for interacting with the Bitwarden Passwordless backend API."""
+
+# Standard library
+from datetime import datetime, timedelta
+from typing import Literal, TypeAlias
+
+# Third party
+from passwordless import (
+    PasswordlessClient,
+    PasswordlessClientBuilder,
+    PasswordlessOptions,
+)
+from pydantic import Field
+
+# Local
+from streamlit_passwordless import common, exceptions, models
+
+
+BackendClient: TypeAlias = PasswordlessClient
+
+
+class BitwardenRegisterConfig(models.BaseModel):
+    r"""The available passkey configuration when registering a new user.
+
+    See the `Bitwarden Passwordless`_ documentation for more info about the parameters.
+
+    .. _ Bitwarden Passwordless: https://docs.passwordless.dev/guide/api.html#register-token
+
+    Parameters
+    ----------
+    attestation : Literal['none', 'direct', 'indirect'], default 'none'
+        WebAuthn attestation conveyance preference. 'direct' and 'indirect' are exclusive to the
+        Enterprise plan of Bitwarden Passwordless. Trial & Pro plans are limited to 'none'.
+
+    authenticator_type : Literal['any', 'platform', 'cross-platform'], default 'any'
+        WebAuthn authenticator attachment modality. 'platform' refers to platform specific options
+        such as Windows Hello, FaceID or TouchID, while 'cross-platform' means roaming devices such
+        as security keys. 'any' (default) means any authenticator type is allowed.
+
+    discoverable : bool, default True
+        True allows the user to sign in without a username or alias by creating a
+        client-side discoverable credential.
+
+    user_verification : Literal['preferred', 'required', 'discouraged'], default 'preferred'
+        Set the preference for how user verification (e.g. PIN code or biometrics) works when
+        authenticating.
+
+    expires_at : datetime, default 'current datetime in UTC + 120 seconds'
+        The timestamp in UTC when the registration token expires and becomes invalid.
+
+    alias_hasing : bool, default True
+        True means that aliases for a user are hashed before they are stored in the
+        Bitwarden Passwordless database.
+    """
+
+    attestation: Literal['none', 'direct', 'indirect'] = 'none'
+    authenticator_type: Literal['any', 'platform', 'cross-platform'] = 'any'
+    discoverable: bool = True
+    user_verification: Literal['preferred', 'required', 'discouraged'] = 'preferred'
+    expires_at: datetime = Field(
+        default_factory=lambda: common.get_current_datetime() + timedelta(seconds=120)
+    )
+    alias_hasing: bool = True
+
+
+def _build_backend_client(private_key: str, url: str) -> BackendClient:
+    r"""Build the Bitwarden Passwordless backend client.
+
+    Parameters
+    ----------
+    private_key : str
+        The private key that the client uses for authenticating with the
+        Bitwarden Passwordless backend API.
+
+    url : str
+        The base url to the backend API.
+
+    Returns
+    -------
+    BackendClient
+        The backend client.
+    """
+
+    try:
+        options = PasswordlessOptions(api_secret=private_key, api_url=url)
+        return PasswordlessClientBuilder(options=options).build()
+    except Exception as e:
+        error_msg = f'Could not build Bitwarden backend client! {type(e).__name__} : {str(e)}'
+        raise exceptions.StreamlitPasswordlessError(error_msg) from None

--- a/src/streamlit_passwordless/bitwarden_passwordless/client.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/client.py
@@ -1,0 +1,61 @@
+r"""The client to use to interact with Bitwarden Passwordless."""
+
+# Standard library
+
+# Third party
+from pydantic import AnyHttpUrl, validator
+
+# Local
+from streamlit_passwordless import models
+from . import backend
+
+
+class BitwardenPasswordlessClient(models.BaseModel):
+    r"""The client for interacting with Bitwarden Passwordless.
+
+    Parameters
+    ----------
+    url : pydantic.AnyHttpUrl
+        The base url of the Bitwarden Passwordless application.
+
+    public_key : str
+        The public key of the Bitwarden Passwordless application.
+
+    private_key : str
+        The private key of the Bitwarden Passwordless application.
+
+    register_config : streamlit_passwordless.BitwardenRegisterConfig or None, default None
+        The passkey configuration when registering a new user.
+        If None the default configuration is used.
+    """
+
+    url: AnyHttpUrl
+    public_key: str
+    private_key: str
+    register_config: backend.BitwardenRegisterConfig | None = None
+    _backend_client: backend.BackendClient
+
+    def __init__(
+        self,
+        url: str,
+        public_key: str,
+        private_key: str,
+        register_config: backend.BitwardenRegisterConfig | None = None,
+    ) -> None:
+        r"""Setup the Bitwarden Passwordless backend client."""
+
+        self._backend_client = backend._build_backend_client(private_key=private_key, url=url)
+        super().__init__(
+            url=url, public_key=public_key, private_key=private_key, register_config=register_config
+        )
+
+    @validator('register_config')
+    def set_register_config_defaults(
+        cls, register_config: backend.BitwardenRegisterConfig | None
+    ) -> backend.BitwardenRegisterConfig:
+        r"""Set the default value of the `register_config` attribute."""
+
+        if register_config is None:
+            return backend.BitwardenRegisterConfig()
+        else:
+            return register_config

--- a/src/streamlit_passwordless/bitwarden_passwordless/frontend.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/frontend.py
@@ -20,8 +20,11 @@ else:
 
 def _register(
     register_token: str, public_key: str, credential_nickname: str, key: str | None = None
-) -> tuple[str, dict]:
+) -> None:
     r"""Register a new user by creating and registring a passkey with the user's device.
+
+    The return value from the javascript function is saved to the session state with a key
+    defined by the `key` parameter. The type of the result is listed in the section `Returns`.
 
     Parameters
     ----------
@@ -35,10 +38,10 @@ def _register(
         A nickname for the passkey credential being registered to use for easier identification
         of the device being registered.
 
-    key : str or None
-        An optional key that uniquely identifies this component. If this is
-        None, and the component's arguments are changed, the component will
-        be re-mounted in the Streamlit frontend and lose its current state.
+    key : str or None, default None
+        An optional key that uniquely identifies this component. If this is None, and the
+        component's arguments are changed, the component will be re-mounted in the Streamlit
+        frontend and lose its current state.
 
     Returns
     -------
@@ -51,15 +54,10 @@ def _register(
         successful or not.
     """
 
-    value = _bitwarden_passwordless_func(
+    _bitwarden_passwordless_func(
         action='register',
         register_token=register_token,
         public_key=public_key,
         credential_nickname=credential_nickname,
         key=key,
     )
-
-    if value is None:
-        return ('', {})
-    else:
-        return value

--- a/src/streamlit_passwordless/bitwarden_passwordless/frontend.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/frontend.py
@@ -6,7 +6,6 @@ from pathlib import Path
 # Third party
 import streamlit.components.v1 as components
 
-
 _RELEASE = True
 _COMPONENT_NAME = 'bitwarden_passwordless'
 _BUILD_DIR = Path(__file__).parent / 'frontend' / 'build'
@@ -14,18 +13,27 @@ _DEV_URL = 'http://localhost:3001'
 
 
 if _RELEASE:
-    _bitwarden_passwordless_func = components.declare_component(_COMPONENT_NAME, path=_BUILD_DIR)
+    _bitwarden_passwordless_func = components.declare_component(_COMPONENT_NAME, path=_BUILD_DIR)  # type: ignore
 else:
     _bitwarden_passwordless_func = components.declare_component(name=_COMPONENT_NAME, url=_DEV_URL)
 
 
-def register(register_token: str, key=None) -> tuple[str, dict]:
+def _register(
+    register_token: str, public_key: str, credential_nickname: str, key: str | None = None
+) -> tuple[str, dict]:
     r"""Register a new user by creating and registring a passkey with the user's device.
 
     Parameters
     ----------
     register_token : str
         The registration token used to authorize the creation of a passkey on the user's device.
+
+    public_key : str
+        The public key of the Bitwarden Passwordless application.
+
+    credential_nickname : str
+        A nickname for the passkey credential being registered to use for easier identification
+        of the device being registered.
 
     key : str or None
         An optional key that uniquely identifies this component. If this is
@@ -43,7 +51,13 @@ def register(register_token: str, key=None) -> tuple[str, dict]:
         successful or not.
     """
 
-    value = _bitwarden_passwordless_func(action='register', token=register_token, key=key)
+    value = _bitwarden_passwordless_func(
+        action='register',
+        register_token=register_token,
+        public_key=public_key,
+        credential_nickname=credential_nickname,
+        key=key,
+    )
 
     if value is None:
         return ('', {})

--- a/src/streamlit_passwordless/bitwarden_passwordless/frontend/package-lock.json
+++ b/src/streamlit_passwordless/bitwarden_passwordless/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bitwarden_passwordless",
       "version": "0.1.0",
       "dependencies": {
+        "@passwordlessdev/passwordless-client": "^1.1.2",
         "streamlit-component-lib": "^2.0.0"
       },
       "devDependencies": {
@@ -3990,6 +3991,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@passwordlessdev/passwordless-client": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@passwordlessdev/passwordless-client/-/passwordless-client-1.1.2.tgz",
+      "integrity": "sha512-Ji4CC+igHsz/UF410v7MGXsax65yOZQOdvDfDg3hNKSNMux1DtKvD1dphfgDmau5mgI1qEVcZutSI/uDDCzJAg=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/src/streamlit_passwordless/bitwarden_passwordless/frontend/package.json
+++ b/src/streamlit_passwordless/bitwarden_passwordless/frontend/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@passwordlessdev/passwordless-client": "^1.1.2",
-    "streamlit-component-lib": "^2.0.0"
+    "@passwordlessdev/passwordless-client": "1.1.2",
+    "streamlit-component-lib": "2.0.0"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -29,9 +29,9 @@
   },
   "homepage": ".",
   "devDependencies": {
-    "@types/jest": "^24.0.0",
-    "@types/node": "^12.0.0",
-    "react-scripts": "^5.0.1",
-    "typescript": "^4.2.0"
+    "@types/jest": "24.0.0",
+    "@types/node": "12.0.0",
+    "react-scripts": "5.0.1",
+    "typescript": "4.2.0"
   }
 }

--- a/src/streamlit_passwordless/bitwarden_passwordless/frontend/package.json
+++ b/src/streamlit_passwordless/bitwarden_passwordless/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@passwordlessdev/passwordless-client": "^1.1.2",
     "streamlit-component-lib": "^2.0.0"
   },
   "scripts": {
@@ -30,7 +31,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",
-    "typescript": "^4.2.0",
-    "react-scripts": "^5.0.1"
+    "react-scripts": "^5.0.1",
+    "typescript": "^4.2.0"
   }
 }

--- a/src/streamlit_passwordless/bitwarden_passwordless/frontend/src/index.tsx
+++ b/src/streamlit_passwordless/bitwarden_passwordless/frontend/src/index.tsx
@@ -1,15 +1,48 @@
-import { Streamlit, RenderData } from "streamlit-component-lib"
+import { Streamlit, RenderData } from "streamlit-component-lib";
+import { Client } from '@passwordlessdev/passwordless-client';
 
-let previousOutput = ''
+let passwordlessClient: Client;
+let clientInitialized: boolean = false;
+let previousToken: string = '';
 
+/**
+ * Initialize an instance of the Bitwarden Passwordless frontend client.
+ *
+ * @param {string} apiKey - The public key of the Bitwarden Passwordless application.
+ *
+ * @returns {Client} - The Bitwarden Passwordless frontend client.
+ */
+function createPasswordlessClient(apiKey: string): Client {
+
+  if (clientInitialized === false) {
+    passwordlessClient = new Client({apiKey: apiKey});
+    clientInitialized = true
+
+    return passwordlessClient
+  } else {
+    return passwordlessClient
+  }
+
+}
+
+/**
+ * The render function that gets called every time the Streamlit Python component gets called.
+ *
+ * @param {Event} event - The input parameters from the Streamlit Python application.
+ */
 function onRender(event: Event): void {
   // Get the RenderData from the event
   const data = (event as CustomEvent<RenderData>).detail;
-  const registerToken = data.args['token'];
+  const apiKey: string = data.args['public_key'];
+  const registerToken: string = data.args['register_token'];
+  const credentialNickname: string = data.args['credential_nickname'];
 
-  if (previousOutput !== registerToken) {
-    previousOutput = registerToken;
-    Streamlit.setComponentValue([registerToken, true]);
+  const client = createPasswordlessClient(apiKey)
+  const {token, error} = client.register(registerToken, credentialNickname)
+
+  if (previousToken !== registerToken) {
+    previousToken = registerToken;
+    Streamlit.setComponentValue([token, error]);
   }
 
 }

--- a/src/streamlit_passwordless/common.py
+++ b/src/streamlit_passwordless/common.py
@@ -1,0 +1,19 @@
+r"""Functions that are common to several modules."""
+
+# Standard library
+from datetime import datetime
+import logging
+from zoneinfo import ZoneInfo
+
+# Third party
+
+# Local
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_current_datetime(tz='UTC') -> datetime:
+    r"""Get the current datetime based on the timezone `tz`."""
+
+    return datetime.now(tz=ZoneInfo(tz))

--- a/src/streamlit_passwordless/components/__init__.py
+++ b/src/streamlit_passwordless/components/__init__.py
@@ -1,0 +1,1 @@
+r"""The components' library contains the web components of streamlit_passwordless."""

--- a/src/streamlit_passwordless/components/config.py
+++ b/src/streamlit_passwordless/components/config.py
@@ -1,0 +1,54 @@
+r"""Contains the Streamlit configuration of the web components."""
+
+# Standard library
+
+# Third party
+import streamlit as st
+
+# Local
+
+
+# =====================================================================================
+# Session state keys
+# =====================================================================================
+
+SK_BP_REGISTER_FROM_IS_VALID = 'bp-register-from-is-valid'
+SK_BP_REGISTER_USER_RESULT = 'sk-bp-register-user-result'
+SK_BP_USER_TO_REGISTER = 'sk-bp-user-to-register'
+
+
+# =====================================================================================
+# Icons
+# =====================================================================================
+
+ICON_ERROR = '🚨'
+ICON_SUCCESS = '✅'
+ICON_WARNING = '⚠️'
+
+
+# =====================================================================================
+# Functions
+# =====================================================================================
+
+
+def init_session_state() -> None:
+    r"""Initialize the session state.
+
+    Session state keys
+    ------------------
+    SK_BP_REGISTER_FROM_IS_VALID : bool, default False
+        True if the Bitwarden Passwordless register form validation is
+        valid and False otherwise.
+
+    SK_BP_USER_TO_REGISTER : models.User | None, default None
+        The user register.
+
+    SK_BP_REGISTER_USER_RESULT : tuple[str, dict] | None, default None
+        The result from the user registration.
+    """
+
+    none_keys = (SK_BP_USER_TO_REGISTER, SK_BP_REGISTER_USER_RESULT)
+    for key in none_keys:
+        st.session_state[key] = None
+
+    st.session_state[SK_BP_REGISTER_FROM_IS_VALID] = False

--- a/src/streamlit_passwordless/components/ids.py
+++ b/src/streamlit_passwordless/components/ids.py
@@ -1,0 +1,10 @@
+r"""The ID:s of components used for identification and session state management."""
+
+# =====================================================================================
+# Register form
+# =====================================================================================
+
+BP_REGISTER_FORM = 'bp-register-form'
+BP_REGISTER_FORM_USERNAME_TEXT_INPUT = 'bp-register-form-username-text-input'
+BP_REGISTER_FORM_DISPLAYNAME_TEXT_INPUT = 'bp-register-form-displayname-text-input'
+BP_REGISTER_FORM_ALIASES_TEXT_INPUT = 'bp-register-form-aliases-text-input'

--- a/src/streamlit_passwordless/components/register_form.py
+++ b/src/streamlit_passwordless/components/register_form.py
@@ -1,0 +1,149 @@
+r"""The register-form component and its callback functions."""
+
+# Standard library
+import logging
+from typing import Literal
+
+# Third party
+import streamlit as st
+
+from streamlit_passwordless import exceptions, models
+from streamlit_passwordless.bitwarden_passwordless.client import BitwardenPasswordlessClient
+
+# Local
+from . import config, ids
+
+logger = logging.getLogger(__name__)
+
+
+def _validate_form() -> None:
+    r"""Validate the input to the registration form and create the user to register.
+
+    The created user is saved to the session state with the key `config.SK_BP_USER_TO_REGISTER`.
+
+    Session state
+    -------------
+    config.SK_BP_USER_TO_REGISTER : models.User | None
+        The user to register. None is returned if a user
+        could not be created from the form data.
+    """
+
+    error_msg = ''
+    username = st.session_state[ids.BP_REGISTER_FORM_USERNAME_TEXT_INPUT]
+    displayname = st.session_state[ids.BP_REGISTER_FORM_DISPLAYNAME_TEXT_INPUT]
+    aliases = st.session_state[ids.BP_REGISTER_FORM_ALIASES_TEXT_INPUT]
+
+    if not username:
+        error_msg = 'The username field is required!'
+        logger.error(error_msg)
+
+    # Create a user
+    if not error_msg:
+        try:
+            st.session_state[config.SK_BP_USER_TO_REGISTER] = models.User(
+                username=username, displayname=displayname, aliases=aliases
+            )
+        except exceptions.StreamlitPasswordlessError as e:
+            error_msg = str(e)
+            logger.error(error_msg)
+
+    if error_msg:
+        st.error(error_msg, icon=config.ICON_ERROR)
+        st.session_state[config.SK_BP_REGISTER_FROM_IS_VALID] = False
+        st.session_state[config.SK_BP_USER_TO_REGISTER] = None
+    else:
+        st.session_state[config.SK_BP_REGISTER_FROM_IS_VALID] = True
+
+
+def bitwarden_register_form(
+    client: BitwardenPasswordlessClient,
+    is_admin: bool = False,
+    pre_authorized: bool = True,
+    title: str = '#### Register a new passkey with your device.',
+    clear_on_submit: bool = False,
+    submit_button_label: str = 'Register',
+    button_type: Literal['primary', 'secondary'] = 'primary',
+) -> None:
+    r"""Render the Bitwarden Passwordless register form.
+
+    Allows the user to register an account with the application by creating
+    and registrering a passkey with the user's device.
+
+    Parameters
+    ----------
+    client : streamlit_passwordless.BitwardenPasswordlessClient
+        The Bitwarden Passwordless client to use for interacting with
+        the Bitwarden Passwordless application.
+
+    is_admin : bool, default False
+        True means that the user will be registered as an admin.
+
+    pre_authorized : bool, default True
+        If True require the username to exist in the pre_authorized table of the database
+        to allow the user to register.
+
+    title : str, default '#### Register a new passkey with your device.'
+        The title of the registration from. Markdown is supported.
+
+    clear_on_submit : bool, default False
+        Clear the form when the submit button is pressed.
+
+    submit_button_label : str, default 'Register'
+        The label of the submit button.
+
+    button_type : Literal['primary', 'secondary'], default 'primary'
+        The styling of the submit button.
+    """
+
+    banner_container = st.empty()
+
+    with st.form(key=ids.BP_REGISTER_FORM, clear_on_submit=clear_on_submit):
+        st.markdown(title)
+        st.text_input(
+            label='Username',
+            placeholder='syn.gates@ax7.com',
+            help='A unique identifier for the account. E.g. an email address.',
+            key=ids.BP_REGISTER_FORM_USERNAME_TEXT_INPUT,
+        )
+        st.text_input(
+            label='Displayname',
+            placeholder='Synyster Gates',
+            help='A descriptive name of the user.',
+            key=ids.BP_REGISTER_FORM_DISPLAYNAME_TEXT_INPUT,
+        )
+        st.text_input(
+            label='Alias',
+            placeholder='syn;gates;afterlife',
+            key=ids.BP_REGISTER_FORM_ALIASES_TEXT_INPUT,
+            help=(
+                'One or more aliases that can be used to sign in to the account. '
+                'Aliases are separated by semicolon (";"). The username is always '
+                'added as an alias.'
+            ),
+        )
+
+        form_submit_button = st.form_submit_button(
+            label=submit_button_label,
+            type=button_type,
+            on_click=_validate_form,
+        )
+
+    user = st.session_state[config.SK_BP_USER_TO_REGISTER]
+
+    if form_submit_button and st.session_state[config.SK_BP_REGISTER_FROM_IS_VALID]:
+        client.register_user(user=user, key=config.SK_BP_REGISTER_USER_RESULT)
+
+    if (register_result := st.session_state[config.SK_BP_REGISTER_USER_RESULT]) is not None:
+        _, error = register_result
+        if error:
+            error_msg = f'Error creating passkey for user ({user})!\nerror : {error}'
+            logger.error(error_msg)
+            with banner_container:
+                st.error(error_msg, icon=config.ICON_ERROR)
+            return
+        else:
+            msg = f'Successfully registered user: {user.username}!'
+            logger.info(msg)
+            with banner_container:
+                st.success(msg, icon=config.ICON_SUCCESS)
+        # Save user to database

--- a/src/streamlit_passwordless/exceptions.py
+++ b/src/streamlit_passwordless/exceptions.py
@@ -19,3 +19,7 @@ class StreamlitPasswordlessError(Exception):
     def __init__(self, message: str, data: Any = None) -> None:
         self.data = data
         super().__init__(message)
+
+
+class RegisterUserError(StreamlitPasswordlessError):
+    r"""Raised for errors when registering a new user."""

--- a/src/streamlit_passwordless/models.py
+++ b/src/streamlit_passwordless/models.py
@@ -19,6 +19,10 @@ class BaseModel(PydanticBaseModel):
         except ValidationError as e:
             raise exceptions.StreamlitPasswordlessError(str(e)) from None
 
+    class Config:
+        r"""Additional configuration for the model."""
+        underscore_attrs_are_private = True
+
 
 class User(BaseModel):
     r"""A user within the streamlit-passwordless data model.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,28 +10,56 @@ import pytest
 
 # Local
 import streamlit_passwordless.bitwarden_passwordless.backend
-from streamlit_passwordless import models, common
-
+from streamlit_passwordless import common, models
 
 # =============================================================================================
 # Models
 # =============================================================================================
 
 
+@pytest.fixture(scope='session')
+def user_id() -> str:
+    r"""The user ID to use for the test user of the test suite."""
+
+    return 'mocked-user_id'
+
+
 @pytest.fixture()
-def mocked_user_id(monkeypatch: pytest.MonkeyPatch) -> str:
+def mocked_user_id(user_id: str, monkeypatch: pytest.MonkeyPatch) -> str:
     r"""Mock the user ID that is generated if a user ID is not supplied to the `User` model.
 
     Returns
     -------
-    mocked_user_id : str
+    user_id : str
         The user_id that is returned from the mock.
     """
 
-    mocked_user_id = 'mocked-user_id'
-    monkeypatch.setattr(models.uuid, 'uuid4', Mock(return_value=mocked_user_id))
+    monkeypatch.setattr(models.uuid, 'uuid4', Mock(return_value=user_id))
 
-    return mocked_user_id
+    return user_id
+
+
+@pytest.fixture(scope='session')
+def user(user_id: str) -> models.User:
+    r"""A test user to use for the test suite.
+
+    Returns
+    -------
+    streamlit_passwordless.models.User
+    """
+
+    return models.User(
+        username='m.shadows',
+        user_id=user_id,
+        email='m.shadows@ax7.com',
+        displayname='M Shadows',
+        aliases=('Matt', 'Shadows'),
+    )
+
+
+# =============================================================================================
+# Common
+# =============================================================================================
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,17 @@
 r"""Fixtures for testing streamlit-passwordless."""
 
 # Standard library
+from datetime import datetime
 from unittest.mock import Mock
+from zoneinfo import ZoneInfo
 
 # Third party
 import pytest
 
 # Local
-from streamlit_passwordless import models
+import streamlit_passwordless.bitwarden_passwordless.backend
+from streamlit_passwordless import models, common
+
 
 # =============================================================================================
 # Models
@@ -28,3 +32,23 @@ def mocked_user_id(monkeypatch: pytest.MonkeyPatch) -> str:
     monkeypatch.setattr(models.uuid, 'uuid4', Mock(return_value=mocked_user_id))
 
     return mocked_user_id
+
+
+@pytest.fixture()
+def mocked_get_current_datetime(monkeypatch: pytest.MonkeyPatch) -> datetime:
+    r"""Set the current datetime to a fixed value.
+
+    Returns
+    -------
+    now : datetime
+        The current datetime fixed to 2023-10-20 13:37:37.
+    """
+
+    now = datetime(2023, 10, 20, 13, 37, 37, tzinfo=ZoneInfo('UTC'))
+    m = Mock(spec_set=common.get_current_datetime, return_value=now)
+
+    monkeypatch.setattr(
+        streamlit_passwordless.bitwarden_passwordless.backend.common, 'get_current_datetime', m
+    )
+
+    return now

--- a/tests/test_bitwarden_passwordless/test_client.py
+++ b/tests/test_bitwarden_passwordless/test_client.py
@@ -1,0 +1,173 @@
+r"""Unit tests for the client module of the bitwarden_passwordless library."""
+
+# Standard library
+from datetime import datetime, timedelta
+
+# Third party
+import pytest
+
+# Local
+from streamlit_passwordless import exceptions
+from streamlit_passwordless.bitwarden_passwordless.client import BitwardenPasswordlessClient
+
+
+# =============================================================================================
+# Tests
+# =============================================================================================
+
+
+class TestBitwardenPasswordlessClient:
+    r"""Tests for the `BitwardenPasswordlessClient` model."""
+
+    def test_init_with_defaults(self, mocked_get_current_datetime: datetime) -> None:
+        r"""Test to initialize an instance with all default values."""
+
+        # Setup
+        # ===========================================================
+        data = {
+            'url': 'https://ax7.com',
+            'public_key': 'public key',
+            'private_key': 'private key',
+        }
+
+        register_config_defaults = {
+            'register_config': {
+                'attestation': 'none',
+                'authenticator_type': 'any',
+                'discoverable': True,
+                'user_verification': 'preferred',
+                'expires_at': mocked_get_current_datetime + timedelta(seconds=120),
+                'alias_hasing': True,
+            },
+        }
+
+        data_exp = data | register_config_defaults
+
+        # Exercise
+        # ===========================================================
+        client = BitwardenPasswordlessClient.parse_obj(data)
+
+        # Verify
+        # ===========================================================
+        assert client.dict() == data_exp
+
+        # Clean up - None
+        # ===========================================================
+
+    def test_init_supply_all_parameters(self) -> None:
+        r"""Test supply values for all parameters."""
+
+        # Setup
+        # ===========================================================
+        data = {
+            'url': 'http://ax7.com',
+            'public_key': 'public key',
+            'private_key': 'private key',
+            'register_config': {
+                'attestation': 'direct',
+                'authenticator_type': 'cross-platform',
+                'discoverable': False,
+                'user_verification': 'required',
+                'expires_at': datetime(2024, 1, 6, 12, 35, 34),
+                'alias_hasing': False,
+            },
+        }
+
+        # Exercise
+        # ===========================================================
+        client = BitwardenPasswordlessClient.parse_obj(data)
+
+        # Verify
+        # ===========================================================
+        assert client.dict() == data
+
+        # Clean up - None
+        # ===========================================================
+
+    def test_init_backend_client(self) -> None:
+        r"""Test that the `_backend_client` attribute is instantiated correctly."""
+
+        # Setup
+        # ===========================================================
+        url = 'https://ax7.com'
+        private_key = 'private key'
+        data = {
+            'url': url,
+            'public_key': 'public key',
+            'private_key': private_key,
+        }
+
+        # Exercise
+        # ===========================================================
+        client = BitwardenPasswordlessClient.parse_obj(data)
+
+        # Verify
+        # ===========================================================
+        assert client._backend_client.options.api_url == url, 'api_url is incorrect!'
+        assert client._backend_client.options.api_secret == private_key, 'api_secret is incorrect!'
+
+        # Clean up - None
+        # ===========================================================
+
+    @pytest.mark.raises
+    def test_invalid_url(self) -> None:
+        r"""Test to supply an invalid url.
+
+        A url without a http or https scheme is invalid.
+        `exceptions.StreamlitPasswordlessError` is expected to be raised.
+        """
+
+        # Setup - None
+        # ===========================================================
+        data = {
+            'url': 'ax7.com',
+            'public_key': 'public key',
+            'private_key': 'private key',
+        }
+
+        # Exercise
+        # ===========================================================
+        with pytest.raises(exceptions.StreamlitPasswordlessError) as exc_info:
+            BitwardenPasswordlessClient.parse_obj(data)
+
+        # Verify
+        # ===========================================================
+        error_msg = exc_info.exconly()
+        print(error_msg)
+
+        assert 'url' in error_msg, 'url not in error message!'
+
+        # Clean up - None
+        # ===========================================================
+
+    @pytest.mark.raises
+    def test_invalid_register_config(self) -> None:
+        r"""Test to supply a register config that is partly invalid.
+
+        "unsafe" is not a valid value for the key `authenticator_type`.
+        `exceptions.StreamlitPasswordlessError` is expected to be raised.
+        """
+
+        # Setup - None
+        # ===========================================================
+        data = {
+            'url': 'http://ax7.com',
+            'public_key': 'public key',
+            'private_key': 'private key',
+            'register_config': {'attestation': 'indirect', 'authenticator_type': 'unsafe'},
+        }
+
+        # Exercise
+        # ===========================================================
+        with pytest.raises(exceptions.StreamlitPasswordlessError) as exc_info:
+            BitwardenPasswordlessClient.parse_obj(data)
+
+        # Verify
+        # ===========================================================
+        error_msg = exc_info.exconly()
+        print(error_msg)
+
+        assert 'authenticator_type' in error_msg, 'authenticator_type not in error message!'
+
+        # Clean up - None
+        # ===========================================================


### PR DESCRIPTION
## Background

Adding the bitwarden_passwordless library, which wraps the Bitwarden Passwordless Python SDK and provides functionality to interact with the Bitwarden Passwordless backend and frontend API:s. The implemented functionality can so far only handle user registration. Also adding the components' library which contains the Streamlit components to expose to the users. Added the `register_form`, which allows a user to register an account with the application by creating and registering a passkey with the user's device.  

## Known issues

The user registration does currently not work due to Streamlit wraps custom components in an iframe, which causes the call WebAuthn passkey creation process to fail. The `navigator.credentials.create` method is not  allowed by default to be called within an iframe. 