### PR TITLE
Updating BitwardenPasswordlessClient

### DIFF
--- a/conda/streamlit_passwordless_dev.yml
+++ b/conda/streamlit_passwordless_dev.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   # Run
   - marshmallow >=3.0
-  - pydantic >=1.10
+  - pydantic <2
   - python >=3.11
   - requests >=2.27
   - streamlit >=1.24

--- a/conda/streamlit_passwordless_dev_linux-64_lock.yml
+++ b/conda/streamlit_passwordless_dev_linux-64_lock.yml
@@ -6,84 +6,63 @@ dependencies:
   - _libgcc_mutex=0.1=main
   - _openmp_mutex=5.1=1_gnu
   - abseil-cpp=20211102.0=hd4dd3e8_0
-  - altair=5.0.1=py311h06a4308_0
-  - anyio=3.5.0=py311h06a4308_0
-  - argon2-cffi=21.3.0=pyhd3eb1b0_0
-  - argon2-cffi-bindings=21.2.0=py311h5eee18b_0
-  - arrow-cpp=11.0.0=h374c478_2
-  - asttokens=2.0.5=pyhd3eb1b0_0
-  - async-lru=2.0.4=py311h06a4308_0
-  - attrs=23.1.0=py311h06a4308_0
-  - aws-c-common=0.6.8=h5eee18b_1
-  - aws-c-event-stream=0.1.6=h6a678d5_6
-  - aws-checksums=0.1.11=h5eee18b_2
-  - aws-sdk-cpp=1.8.185=h721c034_1
-  - babel=2.11.0=py311h06a4308_0
-  - backcall=0.2.0=pyhd3eb1b0_0
-  - beautifulsoup4=4.12.2=py311h06a4308_0
-  - black=23.11.0=py311h06a4308_0
+  - altair=5.0.1=py312h06a4308_0
+  - arrow-cpp=14.0.2=h374c478_1
+  - attrs=23.1.0=py312h06a4308_0
+  - aws-c-auth=0.6.19=h5eee18b_0
+  - aws-c-cal=0.5.20=hdbd6064_0
+  - aws-c-common=0.8.5=h5eee18b_0
+  - aws-c-compression=0.2.16=h5eee18b_0
+  - aws-c-event-stream=0.2.15=h6a678d5_0
+  - aws-c-http=0.6.25=h5eee18b_0
+  - aws-c-io=0.13.10=h5eee18b_0
+  - aws-c-mqtt=0.7.13=h5eee18b_0
+  - aws-c-s3=0.1.51=hdbd6064_0
+  - aws-c-sdkutils=0.1.6=h5eee18b_0
+  - aws-checksums=0.1.13=h5eee18b_0
+  - aws-crt-cpp=0.18.16=h6a678d5_0
+  - aws-sdk-cpp=1.10.55=h721c034_0
+  - black=24.3.0=py312h06a4308_0
   - blas=1.0=openblas
   - bleach=4.1.0=pyhd3eb1b0_0
-  - blinker=1.6.2=py311h06a4308_0
+  - blinker=1.6.2=py312h06a4308_0
   - boost-cpp=1.82.0=hdb19cb5_2
-  - bottleneck=1.3.5=py311hbed6279_0
-  - brotli-python=1.0.9=py311h6a678d5_7
-  - bzip2=1.0.8=h7b6447c_0
+  - bottleneck=1.3.7=py312ha883a20_0
+  - brotli-python=1.0.9=py312h6a678d5_7
+  - bzip2=1.0.8=h5eee18b_5
   - c-ares=1.19.1=h5eee18b_0
-  - ca-certificates=2023.12.12=h06a4308_0
+  - ca-certificates=2024.3.11=h06a4308_0
   - cachetools=4.2.2=pyhd3eb1b0_0
-  - certifi=2023.11.17=py311h06a4308_0
-  - cffi=1.16.0=py311h5eee18b_0
+  - certifi=2024.2.2=py312h06a4308_0
+  - cffi=1.16.0=py312h5eee18b_0
   - charset-normalizer=2.0.4=pyhd3eb1b0_0
-  - click=8.1.7=py311h06a4308_0
-  - cmarkgfm=2022.10.27=py311h5eee18b_0
-  - comm=0.1.2=py311h06a4308_0
-  - cryptography=41.0.7=py311hdda0065_0
+  - click=8.1.7=py312h06a4308_0
+  - cmarkgfm=2022.10.27=py312h5eee18b_0
+  - cryptography=42.0.5=py312hdda0065_0
   - dbus=1.13.18=hb2f20db_0
-  - debugpy=1.6.7=py311h6a678d5_0
-  - decorator=5.1.1=pyhd3eb1b0_0
-  - defusedxml=0.7.1=pyhd3eb1b0_0
-  - docutils=0.18.1=py311h06a4308_3
-  - executing=0.8.3=pyhd3eb1b0_0
-  - expat=2.5.0=h6a678d5_0
-  - flake8=6.1.0=py311h06a4308_0
+  - docutils=0.18.1=py312h06a4308_3
+  - expat=2.6.2=h6a678d5_0
+  - flake8=7.0.0=py312h06a4308_0
   - freetype=2.12.1=h4a9f257_0
-  - gflags=2.2.2=he6710b0_0
-  - giflib=5.2.1=h5eee18b_3
+  - gflags=2.2.2=h6a678d5_1
   - gitdb=4.0.7=pyhd3eb1b0_0
-  - gitpython=3.1.37=py311h06a4308_0
-  - glib=2.69.1=he621ea3_2
-  - glog=0.5.0=h2531618_0
+  - gitpython=3.1.37=py312h06a4308_0
+  - glib=2.78.4=h6a678d5_0
+  - glib-tools=2.78.4=h6a678d5_0
+  - glog=0.5.0=h6a678d5_1
   - grpc-cpp=1.48.2=he1ff14a_1
   - icu=73.1=h6a678d5_0
-  - idna=3.4=py311h06a4308_0
-  - importlib-metadata=6.0.0=py311h06a4308_0
-  - importlib_metadata=6.0.0=hd3eb1b0_0
+  - idna=3.4=py312h06a4308_0
+  - importlib-metadata=7.0.1=py312h06a4308_0
   - iniconfig=1.1.1=pyhd3eb1b0_0
-  - ipykernel=6.25.0=py311h92b7b1e_0
-  - ipython=8.15.0=py311h06a4308_0
-  - ipython_genutils=0.2.0=pyhd3eb1b0_1
-  - ipywidgets=7.6.5=pyhd3eb1b0_2
   - isort=5.9.3=pyhd3eb1b0_0
   - jaraco.classes=3.2.1=pyhd3eb1b0_0
-  - jedi=0.18.1=py311h06a4308_1
   - jeepney=0.7.1=pyhd3eb1b0_0
-  - jinja2=3.1.2=py311h06a4308_0
+  - jinja2=3.1.3=py312h06a4308_0
   - jpeg=9e=h5eee18b_1
-  - json5=0.9.6=pyhd3eb1b0_0
-  - jsonschema=4.19.2=py311h06a4308_0
-  - jsonschema-specifications=2023.7.1=py311h06a4308_0
-  - jupyter-lsp=2.2.0=py311h06a4308_0
-  - jupyter_client=8.6.0=py311h06a4308_0
-  - jupyter_core=5.5.0=py311h06a4308_0
-  - jupyter_events=0.8.0=py311h06a4308_0
-  - jupyter_server=2.10.0=py311h06a4308_0
-  - jupyter_server_terminals=0.4.4=py311h06a4308_1
-  - jupyterlab=4.0.8=py311h06a4308_0
-  - jupyterlab_pygments=0.1.2=py_0
-  - jupyterlab_server=2.25.1=py311h06a4308_0
-  - jupyterlab_widgets=3.0.9=py311h06a4308_0
-  - keyring=23.13.1=py311h06a4308_0
+  - jsonschema=4.19.2=py312h06a4308_0
+  - jsonschema-specifications=2023.7.1=py312h06a4308_0
+  - keyring=24.3.1=py312h06a4308_0
   - krb5=1.20.1=h143b758_1
   - lcms2=2.12=h3be6417_0
   - ld_impl_linux-64=2.38=h1181459_1
@@ -92,7 +71,7 @@ dependencies:
   - libbrotlicommon=1.0.9=h5eee18b_7
   - libbrotlidec=1.0.9=h5eee18b_7
   - libbrotlienc=1.0.9=h5eee18b_7
-  - libcurl=8.4.0=h251f7ec_1
+  - libcurl=8.5.0=h251f7ec_0
   - libdeflate=1.17=h5eee18b_1
   - libedit=3.1.20230828=h5eee18b_0
   - libev=4.33=h7f8727e_1
@@ -101,132 +80,97 @@ dependencies:
   - libgcc-ng=11.2.0=h1234567_1
   - libgfortran-ng=11.2.0=h00389a5_1
   - libgfortran5=11.2.0=h1234567_1
+  - libglib=2.78.4=hdc74915_0
   - libgomp=11.2.0=h1234567_1
+  - libiconv=1.16=h7f8727e_2
   - libnghttp2=1.57.0=h2d74bed_0
   - libopenblas=0.3.21=h043d6bf_0
   - libpng=1.6.39=h5eee18b_0
   - libprotobuf=3.20.3=he621ea3_0
-  - libsodium=1.0.18=h7b6447c_0
   - libssh2=1.10.0=hdbd6064_2
   - libstdcxx-ng=11.2.0=h1234567_1
   - libthrift=0.15.0=h1795dd8_2
   - libtiff=4.5.1=h6a678d5_0
   - libuuid=1.41.5=h5eee18b_0
-  - libwebp=1.3.2=h11a3e52_0
   - libwebp-base=1.3.2=h5eee18b_0
   - lz4-c=1.9.4=h6a678d5_0
-  - markdown-it-py=2.2.0=py311h06a4308_1
-  - markupsafe=2.1.1=py311h5eee18b_0
-  - marshmallow=3.19.0=py311h06a4308_0
-  - matplotlib-inline=0.1.6=py311h06a4308_0
+  - markdown-it-py=2.2.0=py312h06a4308_1
+  - markupsafe=2.1.3=py312h5eee18b_0
+  - marshmallow=3.19.0=py312h06a4308_0
   - mccabe=0.7.0=pyhd3eb1b0_0
-  - mdurl=0.1.0=py311h06a4308_0
-  - mistune=2.0.4=py311h06a4308_0
-  - more-itertools=10.1.0=py311h06a4308_0
-  - mypy=1.5.1=py311h06a4308_0
-  - mypy_extensions=1.0.0=py311h06a4308_0
-  - nbclient=0.8.0=py311h06a4308_0
-  - nbconvert=7.10.0=py311h06a4308_0
-  - nbformat=5.9.2=py311h06a4308_0
+  - mdurl=0.1.0=py312h06a4308_0
+  - more-itertools=10.1.0=py312h06a4308_0
+  - mypy=1.8.0=py312h5eee18b_0
+  - mypy_extensions=1.0.0=py312h06a4308_0
   - ncurses=6.4=h6a678d5_0
-  - nest-asyncio=1.5.6=py311h06a4308_0
-  - notebook=7.0.6=py311h06a4308_0
-  - notebook-shim=0.2.3=py311h06a4308_0
-  - numexpr=2.8.7=py311h812550d_0
-  - numpy=1.26.2=py311h24aa872_0
-  - numpy-base=1.26.2=py311hbfb1bba_0
-  - openssl=3.0.12=h7f8727e_0
+  - numexpr=2.8.7=py312he7dcb8a_0
+  - numpy=1.26.4=py312h2809609_0
+  - numpy-base=1.26.4=py312he1a6c75_0
+  - openjpeg=2.4.0=h3ad879b_0
+  - openssl=3.0.13=h7f8727e_0
   - orc=1.7.4=hb3bc3d3_1
-  - overrides=7.4.0=py311h06a4308_0
-  - packaging=23.1=py311h06a4308_0
-  - pandas=2.1.4=py311ha02d727_0
-  - pandocfilters=1.5.0=pyhd3eb1b0_0
-  - parso=0.8.3=pyhd3eb1b0_0
-  - pathspec=0.10.3=py311h06a4308_0
-  - pcre=8.45=h295c915_0
-  - pexpect=4.8.0=pyhd3eb1b0_3
-  - pickleshare=0.7.5=pyhd3eb1b0_1003
-  - pillow=9.4.0=py311h6a678d5_1
-  - pip=23.3.1=py311h06a4308_0
-  - pkginfo=1.9.6=py311h06a4308_0
-  - platformdirs=3.10.0=py311h06a4308_0
-  - pluggy=1.0.0=py311h06a4308_1
-  - prometheus_client=0.14.1=py311h06a4308_0
-  - prompt-toolkit=3.0.36=py311h06a4308_0
-  - protobuf=3.20.3=py311h6a678d5_0
-  - psutil=5.9.0=py311h5eee18b_0
-  - ptyprocess=0.7.0=pyhd3eb1b0_2
-  - pure_eval=0.2.2=pyhd3eb1b0_0
-  - pyarrow=11.0.0=py311hd8e8d9b_1
-  - pycodestyle=2.11.1=py311h06a4308_0
+  - packaging=23.2=py312h06a4308_0
+  - pandas=2.2.1=py312h526ad5a_0
+  - pathspec=0.10.3=py312h06a4308_0
+  - pcre2=10.42=hebb0a14_0
+  - pillow=10.2.0=py312h5eee18b_0
+  - pip=23.3.1=py312h06a4308_0
+  - pkginfo=1.9.6=py312h06a4308_0
+  - platformdirs=3.10.0=py312h06a4308_0
+  - pluggy=1.0.0=py312h06a4308_1
+  - protobuf=3.20.3=py312h6a678d5_0
+  - psutil=5.9.0=py312h5eee18b_0
+  - pyarrow=14.0.2=py312hb107042_0
+  - pycodestyle=2.11.1=py312h06a4308_0
   - pycparser=2.21=pyhd3eb1b0_0
-  - pydantic=1.10.12=py311h5eee18b_1
-  - pydeck=0.8.0=py311h06a4308_0
-  - pyflakes=3.1.0=py311h06a4308_0
-  - pygments=2.15.1=py311h06a4308_1
-  - pympler=0.9=py_0
-  - pyopenssl=23.2.0=py311h06a4308_0
-  - pyproject_hooks=1.0.0=py311h06a4308_0
-  - pysocks=1.7.1=py311h06a4308_0
-  - pytest=7.4.0=py311h06a4308_0
-  - python=3.11.5=h955ad1f_0
-  - python-build=0.10.0=py311h06a4308_0
+  - pydantic=1.10.12=py312h5eee18b_1
+  - pydeck=0.8.0=py312h06a4308_2
+  - pyflakes=3.2.0=py312h06a4308_0
+  - pygments=2.15.1=py312h06a4308_1
+  - pyproject_hooks=1.0.0=py312h06a4308_0
+  - pysocks=1.7.1=py312h06a4308_0
+  - pytest=7.4.0=py312h06a4308_0
+  - python=3.12.3=h996f2a0_0
+  - python-build=0.10.0=py312h06a4308_0
   - python-dateutil=2.8.2=pyhd3eb1b0_0
-  - python-dotenv=0.21.0=py311h06a4308_0
-  - python-fastjsonschema=2.16.2=py311h06a4308_0
-  - python-json-logger=2.0.7=py311h06a4308_0
+  - python-dotenv=0.21.0=py312h06a4308_0
   - python-tzdata=2023.3=pyhd3eb1b0_0
-  - pytz=2023.3.post1=py311h06a4308_0
-  - pyyaml=6.0.1=py311h5eee18b_0
-  - pyzmq=25.1.0=py311h6a678d5_0
+  - pytz=2023.3.post1=py312h06a4308_0
+  - pyyaml=6.0.1=py312h5eee18b_0
   - re2=2022.04.01=h295c915_0
   - readline=8.2=h5eee18b_0
-  - readme_renderer=40.0=py311h06a4308_0
-  - referencing=0.30.2=py311h06a4308_0
-  - requests=2.31.0=py311h06a4308_0
-  - requests-toolbelt=1.0.0=py311h06a4308_0
-  - rfc3339-validator=0.1.4=py311h06a4308_0
+  - readme_renderer=40.0=py312h06a4308_0
+  - referencing=0.30.2=py312h06a4308_0
+  - requests=2.31.0=py312h06a4308_1
+  - requests-toolbelt=1.0.0=py312h06a4308_0
   - rfc3986=1.4.0=pyhd3eb1b0_0
-  - rfc3986-validator=0.1.1=py311h06a4308_0
-  - rich=13.3.5=py311h06a4308_0
-  - rpds-py=0.10.6=py311hb02cf49_0
-  - secretstorage=3.3.1=py311h06a4308_1
-  - send2trash=1.8.2=py311h06a4308_0
-  - setuptools=68.2.2=py311h06a4308_0
+  - rich=13.3.5=py312h06a4308_1
+  - rpds-py=0.10.6=py312hb02cf49_0
+  - s2n=1.3.27=hdbd6064_0
+  - secretstorage=3.3.1=py312h06a4308_1
+  - setuptools=68.2.2=py312h06a4308_0
   - six=1.16.0=pyhd3eb1b0_1
   - smmap=4.0.0=pyhd3eb1b0_0
   - snappy=1.1.10=h6a678d5_1
-  - sniffio=1.2.0=py311h06a4308_1
-  - soupsieve=2.5=py311h06a4308_0
   - sqlite=3.41.2=h5eee18b_0
-  - stack_data=0.2.0=pyhd3eb1b0_0
-  - streamlit=1.26.0=py311h06a4308_0
-  - tenacity=8.2.2=py311h06a4308_0
-  - terminado=0.17.1=py311h06a4308_0
-  - tinycss2=1.2.1=py311h06a4308_0
+  - streamlit=1.32.0=py312h06a4308_0
+  - tenacity=8.2.2=py312h06a4308_1
   - tk=8.6.12=h1ccaba5_0
   - toml=0.10.2=pyhd3eb1b0_0
-  - toolz=0.12.0=py311h06a4308_0
-  - tornado=6.3.3=py311h5eee18b_0
-  - traitlets=5.7.1=py311h06a4308_0
-  - twine=4.0.2=py311h06a4308_0
-  - typing-extensions=4.7.1=py311h06a4308_0
-  - typing_extensions=4.7.1=py311h06a4308_0
-  - tzdata=2023c=h04d1e81_0
-  - tzlocal=2.1=py311h06a4308_1
-  - urllib3=1.26.18=py311h06a4308_0
-  - utf8proc=2.6.1=h27cfd23_0
-  - validators=0.18.2=pyhd3eb1b0_0
-  - watchdog=2.1.6=py311h06a4308_0
-  - wcwidth=0.2.5=pyhd3eb1b0_0
-  - webencodings=0.5.1=py311h06a4308_1
-  - websocket-client=0.58.0=py311h06a4308_4
-  - wheel=0.41.2=py311h06a4308_0
-  - widgetsnbextension=3.5.2=py311h06a4308_1
-  - xz=5.4.5=h5eee18b_0
+  - toolz=0.12.0=py312h06a4308_0
+  - tornado=6.3.3=py312h5eee18b_0
+  - twine=4.0.2=py312h06a4308_0
+  - typing-extensions=4.9.0=py312h06a4308_1
+  - typing_extensions=4.9.0=py312h06a4308_1
+  - tzdata=2024a=h04d1e81_0
+  - urllib3=2.1.0=py312h06a4308_1
+  - utf8proc=2.6.1=h5eee18b_1
+  - watchdog=2.1.6=py312h06a4308_0
+  - webencodings=0.5.1=py312h06a4308_2
+  - wheel=0.41.2=py312h06a4308_0
+  - xz=5.4.6=h5eee18b_0
   - yaml=0.2.5=h7b6447c_0
-  - zeromq=4.3.4=h2531618_0
-  - zipp=3.11.0=py311h06a4308_0
+  - zipp=3.17.0=py312h06a4308_0
   - zlib=1.2.13=h5eee18b_0
   - zstd=1.5.5=hc292b87_0
   - pip:

--- a/src/streamlit_passwordless/bitwarden_passwordless/backend.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/backend.py
@@ -52,7 +52,7 @@ class BitwardenRegisterConfig(models.BaseModel):
         When the registration token expires and becomes invalid defined as an offset
         from the start of the registration process.
 
-    alias_hasing : bool, default True
+    alias_hashing : bool, default True
         True means that aliases for a user are hashed before they are stored in the
         Bitwarden Passwordless database.
     """
@@ -62,7 +62,7 @@ class BitwardenRegisterConfig(models.BaseModel):
     discoverable: bool = True
     user_verification: Literal['preferred', 'required', 'discouraged'] = 'preferred'
     validity: timedelta = timedelta(seconds=120)
-    alias_hasing: bool = True
+    alias_hashing: bool = True
 
     @property
     def expires_at(self) -> datetime:
@@ -134,7 +134,7 @@ def _create_register_token(
         discoverable=register_config.discoverable,
         user_verification=register_config.user_verification,
         aliases=user.aliases,
-        alias_hashing=register_config.alias_hasing,
+        alias_hashing=register_config.alias_hashing,
         expires_at=register_config.expires_at,
     )
 

--- a/src/streamlit_passwordless/models.py
+++ b/src/streamlit_passwordless/models.py
@@ -4,7 +4,8 @@ r"""The data models of streamlit-passwordless."""
 import uuid
 
 # Third party
-from pydantic import BaseModel as PydanticBaseModel, validator, ValidationError
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import ValidationError, field_validator
 
 # Local
 from . import exceptions
@@ -18,10 +19,6 @@ class BaseModel(PydanticBaseModel):
             super().__init__(**kwargs)
         except ValidationError as e:
             raise exceptions.StreamlitPasswordlessError(str(e)) from None
-
-    class Config:
-        r"""Additional configuration for the model."""
-        underscore_attrs_are_private = True
 
 
 class User(BaseModel):
@@ -54,13 +51,13 @@ class User(BaseModel):
     displayname: str | None = None
     aliases: tuple[str, ...] | str | None = None
 
-    @validator('user_id', always=True)
+    @field_validator('user_id')
     def generate_user_id(cls, v: str | None, values) -> str:
         r"""Generate a user ID if not supplied."""
 
         return str(uuid.uuid4()) if v is None else v
 
-    @validator('aliases', always=True)
+    @field_validator('aliases')
     def process_aliases(cls, aliases: tuple[str, ...] | str | None) -> tuple[str, ...] | None:
         r"""Convert multiple aliases in a string to a tuple by splitting on the semicolon ";"."""
 

--- a/src/streamlit_passwordless/models.py
+++ b/src/streamlit_passwordless/models.py
@@ -5,7 +5,7 @@ import uuid
 
 # Third party
 from pydantic import BaseModel as PydanticBaseModel
-from pydantic import ValidationError, field_validator
+from pydantic import Field, ValidationError, field_validator
 
 # Local
 from . import exceptions
@@ -46,13 +46,13 @@ class User(BaseModel):
     """
 
     username: str
-    user_id: str | None = None
+    user_id: str | None = Field(default=None, validate_default=True)
     email: str | None = None
     displayname: str | None = None
-    aliases: tuple[str, ...] | str | None = None
+    aliases: tuple[str, ...] | str | None = Field(default=None, validate_default=True)
 
     @field_validator('user_id')
-    def generate_user_id(cls, v: str | None, values) -> str:
+    def generate_user_id(cls, v: str | None) -> str:
         r"""Generate a user ID if not supplied."""
 
         return str(uuid.uuid4()) if v is None else v

--- a/tests/test_bitwarden_passwordless/test_backend.py
+++ b/tests/test_bitwarden_passwordless/test_backend.py
@@ -1,10 +1,24 @@
 r"""Unit tests for the backend module of the bitwarden_passwordless library."""
 
 # Standard library
+from collections import namedtuple
 from datetime import datetime, timedelta
+from unittest.mock import Mock
+
+# Third party
+import pytest
 
 # Local
-from streamlit_passwordless.bitwarden_passwordless.backend import BitwardenRegisterConfig
+from streamlit_passwordless import exceptions, models
+from streamlit_passwordless.bitwarden_passwordless import backend
+from streamlit_passwordless.bitwarden_passwordless.backend import (
+    BackendClient,
+    BitwardenRegisterConfig,
+    PasswordlessError,
+    RegisterToken,
+    _build_backend_client,
+    _create_register_token,
+)
 
 # =============================================================================================
 # Tests
@@ -52,6 +66,146 @@ class TestBitwardenRegisterConfig:
         # Verify
         # ===========================================================
         assert config.expires_at == expires_at_exp
+
+        # Clean up - None
+        # ===========================================================
+
+
+class TestBuildBackendClient:
+    r"""Tests for the function `_build_backend_client`."""
+
+    def test_build_backend_client(self) -> None:
+        r"""Test building an instance of the backend client."""
+
+        # Setup
+        # ===========================================================
+        private_key = 'private key'
+        url = 'https://afterlife.ax7.com'
+
+        # Exercise
+        # ===========================================================
+        client = _build_backend_client(private_key=private_key, url=url)
+
+        # Verify
+        # ===========================================================
+        assert client.options.api_url == url, 'api_url is incorrect!'
+        assert client.options.api_secret == private_key, 'api_secret is incorrect!'
+
+        # Clean up - None
+        # ===========================================================
+
+    @pytest.mark.raises
+    def test_raises_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        r"""Test that a raised exception will be re-raised as `StreamlitPasswordlessError`."""
+
+        # Setup
+        # ===========================================================
+        error_msg_text = 'Unexpected!'
+        error_msg_exp = f'Could not build Bitwarden backend client! ValueError : {error_msg_text}'
+        monkeypatch.setattr(
+            backend.PasswordlessClientBuilder,
+            'build',
+            Mock(side_effect=ValueError(error_msg_text)),
+        )
+
+        # Exercise
+        # ===========================================================
+        with pytest.raises(exceptions.StreamlitPasswordlessError) as exc_info:
+            _build_backend_client(private_key='private_key', url='url')
+
+        # Verify
+        # ===========================================================
+        exc_info_text = exc_info.exconly()
+        print(exc_info_text)
+        error_msg = exc_info.value.args[0]
+
+        assert error_msg == error_msg_exp
+
+        # Clean up - None
+        # ===========================================================
+
+
+class TestCreateRegisterToken:
+    r"""Tests for the function `_create_register_token`."""
+
+    def test_called_correctly(
+        self, monkeypatch: pytest.MonkeyPatch, mocked_get_current_datetime: datetime
+    ) -> None:
+        r"""Test that the `_create_register_token` function can be called correctly."""
+
+        # Setup
+        # ===========================================================
+        register_token_mock_return = namedtuple('register_token_mock_return', 'token')
+        token_exp = 'syn.gates'
+
+        user = models.User(username='SynGates')
+
+        validity = timedelta(seconds=120)
+        expires_at = mocked_get_current_datetime + validity
+        monkeypatch.setattr(BitwardenRegisterConfig, 'expires_at', expires_at)
+
+        client = Mock(spec_set=BackendClient, name='MockedBackendClient')
+        client.register_token.return_value = register_token_mock_return(token=token_exp)
+
+        bitwarden_register_config = BitwardenRegisterConfig()
+
+        register_config = user.model_dump(
+            exclude={'email', 'displayname'}
+        ) | bitwarden_register_config.model_dump(exclude={'validity'})
+
+        register_config['display_name'] = user.displayname
+        register_config['expires_at'] = expires_at
+
+        input_register_config_exp = RegisterToken(**register_config)
+
+        # Exercise
+        # ===========================================================
+        token = _create_register_token(
+            client=client, user=user, register_config=bitwarden_register_config
+        )
+
+        # Verify
+        # ===========================================================
+        assert token == token_exp, 'token is incorrect!'
+        client.register_token.assert_called_once_with(register_token=input_register_config_exp)
+
+        # Clean up - None
+        # ===========================================================
+
+    @pytest.mark.raises
+    def test_raises_register_user_error(self) -> None:
+        r"""Test that a raised `PasswordlessError` will be re-raised as a `RegisterUserError`."""
+
+        # Setup
+        # ===========================================================
+        problem_details = {'error': True}
+        user = models.User(username='SynGates')
+
+        client = Mock(spec_set=BackendClient, name='MockedBackendClient')
+        client.register_token.side_effect = PasswordlessError(problem_details=problem_details)
+
+        # Exercise
+        # ===========================================================
+        with pytest.raises(exceptions.RegisterUserError) as exc_info:
+            _create_register_token(
+                client=client, user=user, register_config=BitwardenRegisterConfig()
+            )
+
+        # Verify
+        # ===========================================================
+        error_msg = exc_info.exconly()
+        print(error_msg)
+
+        assert 'Error creating register token!' in error_msg, 'Error message is incorrect!'
+        assert f'{problem_details}' in error_msg, 'Error message problem_details are incorrect!'
+
+        assert (
+            problem_details == exc_info.value.data['problem_details']
+        ), 'problem_details are incorrect!'
+
+        assert isinstance(
+            exc_info.value.data['input_register_config'], RegisterToken
+        ), 'input_register_config is incorrect!'
 
         # Clean up - None
         # ===========================================================

--- a/tests/test_bitwarden_passwordless/test_backend.py
+++ b/tests/test_bitwarden_passwordless/test_backend.py
@@ -1,0 +1,57 @@
+r"""Unit tests for the backend module of the bitwarden_passwordless library."""
+
+# Standard library
+from datetime import datetime, timedelta
+
+# Local
+from streamlit_passwordless.bitwarden_passwordless.backend import BitwardenRegisterConfig
+
+# =============================================================================================
+# Tests
+# =============================================================================================
+
+
+class TestBitwardenRegisterConfig:
+    r"""Tests for the `BitwardenRegisterConfig` model."""
+
+    def test_expires_at_property_with_default_value_for_validity(
+        self, mocked_get_current_datetime: datetime
+    ) -> None:
+        r"""Test the `expires_at` property with the default value for `validity`."""
+
+        # Setup
+        # ===========================================================
+        validity = timedelta(seconds=120)
+        expires_at_exp = mocked_get_current_datetime + validity
+
+        # Exercise
+        # ===========================================================
+        config = BitwardenRegisterConfig()
+
+        # Verify
+        # ===========================================================
+        assert config.expires_at == expires_at_exp
+
+        # Clean up - None
+        # ===========================================================
+
+    def test_expires_at_property_with_custom_value_for_validity(
+        self, mocked_get_current_datetime: datetime
+    ) -> None:
+        r"""Test the `expires_at` property with a custom value for `validity`."""
+
+        # Setup
+        # ===========================================================
+        validity = timedelta(hours=1)
+        expires_at_exp = mocked_get_current_datetime + validity
+
+        # Exercise
+        # ===========================================================
+        config = BitwardenRegisterConfig(validity=validity)
+
+        # Verify
+        # ===========================================================
+        assert config.expires_at == expires_at_exp
+
+        # Clean up - None
+        # ===========================================================

--- a/tests/test_bitwarden_passwordless/test_client.py
+++ b/tests/test_bitwarden_passwordless/test_client.py
@@ -7,9 +7,9 @@ from unittest.mock import Mock
 # Third party
 import pytest
 from passwordless import PasswordlessError
+from pydantic import AnyHttpUrl
 
 # Local
-import streamlit_passwordless.bitwarden_passwordless.client
 from streamlit_passwordless import exceptions, models
 from streamlit_passwordless.bitwarden_passwordless.client import BitwardenPasswordlessClient
 
@@ -27,7 +27,6 @@ class TestBitwardenPasswordlessClient:
         # Setup
         # ===========================================================
         data = {
-            'url': 'https://ax7.com',
             'public_key': 'public key',
             'private_key': 'private key',
         }
@@ -44,14 +43,15 @@ class TestBitwardenPasswordlessClient:
         }
 
         data_exp = data | register_config_defaults
+        data_exp['url'] = AnyHttpUrl('https://v4.passwordless.dev')  # type: ignore
 
         # Exercise
         # ===========================================================
-        client = BitwardenPasswordlessClient.parse_obj(data)
+        client = BitwardenPasswordlessClient.model_validate(data)
 
         # Verify
         # ===========================================================
-        assert client.dict() == data_exp
+        assert client.model_dump() == data_exp
 
         # Clean up - None
         # ===========================================================
@@ -75,13 +75,16 @@ class TestBitwardenPasswordlessClient:
             },
         }
 
+        data_exp = data.copy()
+        data_exp['url'] = AnyHttpUrl(data['url'])  # type: ignore
+
         # Exercise
         # ===========================================================
-        client = BitwardenPasswordlessClient.parse_obj(data)
+        client = BitwardenPasswordlessClient.model_validate(data)
 
         # Verify
         # ===========================================================
-        assert client.dict() == data
+        assert client.model_dump() == data_exp
 
         # Clean up - None
         # ===========================================================
@@ -92,6 +95,7 @@ class TestBitwardenPasswordlessClient:
         # Setup
         # ===========================================================
         url = 'https://ax7.com'
+        url_exp = 'https://ax7.com/'
         private_key = 'private key'
         data = {
             'url': url,
@@ -101,11 +105,11 @@ class TestBitwardenPasswordlessClient:
 
         # Exercise
         # ===========================================================
-        client = BitwardenPasswordlessClient.parse_obj(data)
+        client = BitwardenPasswordlessClient.model_validate(data)
 
         # Verify
         # ===========================================================
-        assert client._backend_client.options.api_url == url, 'api_url is incorrect!'
+        assert client._backend_client.options.api_url == url_exp, 'api_url is incorrect!'
         assert client._backend_client.options.api_secret == private_key, 'api_secret is incorrect!'
 
         # Clean up - None
@@ -130,7 +134,7 @@ class TestBitwardenPasswordlessClient:
         # Exercise
         # ===========================================================
         with pytest.raises(exceptions.StreamlitPasswordlessError) as exc_info:
-            BitwardenPasswordlessClient.parse_obj(data)
+            BitwardenPasswordlessClient.model_validate(data)
 
         # Verify
         # ===========================================================
@@ -162,7 +166,7 @@ class TestBitwardenPasswordlessClient:
         # Exercise
         # ===========================================================
         with pytest.raises(exceptions.StreamlitPasswordlessError) as exc_info:
-            BitwardenPasswordlessClient.parse_obj(data)
+            BitwardenPasswordlessClient.model_validate(data)
 
         # Verify
         # ===========================================================

--- a/tests/test_bitwarden_passwordless/test_client.py
+++ b/tests/test_bitwarden_passwordless/test_client.py
@@ -37,7 +37,7 @@ class TestBitwardenPasswordlessClient:
                 'authenticator_type': 'any',
                 'discoverable': True,
                 'user_verification': 'preferred',
-                'expires_at': mocked_get_current_datetime + timedelta(seconds=120),
+                'validity': timedelta(seconds=120),
                 'alias_hasing': True,
             },
         }
@@ -70,7 +70,7 @@ class TestBitwardenPasswordlessClient:
                 'authenticator_type': 'cross-platform',
                 'discoverable': False,
                 'user_verification': 'required',
-                'expires_at': datetime(2024, 1, 6, 12, 35, 34),
+                'validity': timedelta(hours=1),
                 'alias_hasing': False,
             },
         }

--- a/tests/test_bitwarden_passwordless/test_client.py
+++ b/tests/test_bitwarden_passwordless/test_client.py
@@ -38,7 +38,7 @@ class TestBitwardenPasswordlessClient:
                 'discoverable': True,
                 'user_verification': 'preferred',
                 'validity': timedelta(seconds=120),
-                'alias_hasing': True,
+                'alias_hashing': True,
             },
         }
 
@@ -71,7 +71,7 @@ class TestBitwardenPasswordlessClient:
                 'discoverable': False,
                 'user_verification': 'required',
                 'validity': timedelta(hours=1),
-                'alias_hasing': False,
+                'alias_hashing': False,
             },
         }
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,7 +9,6 @@ import pytest
 # Local
 from streamlit_passwordless import exceptions, models
 
-
 # =============================================================================================
 # Tests
 # =============================================================================================
@@ -25,19 +24,20 @@ class TestUser:
         # ===========================================================
         data = {
             'username': 'm.shadows',
-            'user_id': mocked_user_id,
             'email': None,
             'displayname': None,
             'aliases': None,
         }
+        data_exp = data.copy()
+        data_exp['user_id'] = mocked_user_id
 
         # Exercise
         # ===========================================================
-        user = models.User(**data)
+        user = models.User.model_validate(data)
 
         # Verify
         # ===========================================================
-        assert user.dict() == data
+        assert user.model_dump() == data_exp
 
         # Clean up - None
         # ===========================================================
@@ -57,11 +57,11 @@ class TestUser:
 
         # Exercise
         # ===========================================================
-        user = models.User(**data)
+        user = models.User.model_validate(data)
 
         # Verify
         # ===========================================================
-        assert user.dict() == data
+        assert user.model_dump() == data
 
         # Clean up - None
         # ===========================================================


### PR DESCRIPTION
Adding support for Pydantic v2 to all Pydantic models.

Fixing issue with the `BitwardenRegisterConfig.expires_at`  attribute being defined as an absolute datetime, which causes issues  because we do not know when the user will trigger the registration workflow from the register form.
Changed  `expires_at` to be a property, which defines the expiry datetime of the registration token based on the current UTC time and  the newly added  `validity` parameter.  `validity` is a timedelta object that describes the number of seconds from the start of the registration process that the register token is valid for.

Adding unit tests for the backend module.