### PR TITLE
Fixing issue #5 iPhone : Client error "The document is not focused"

### DIFF
--- a/src/streamlit_passwordless/__init__.py
+++ b/src/streamlit_passwordless/__init__.py
@@ -13,6 +13,8 @@ from streamlit_passwordless.bitwarden_passwordless import (
     BitwardenPasswordlessClient,
     BitwardenPasswordlessVerifiedUser,
     BitwardenRegisterConfig,
+    register_button,
+    sign_in_button,
 )
 from streamlit_passwordless.components import (
     ICON_ERROR,
@@ -48,6 +50,8 @@ __all__ = [
     'BitwardenPasswordlessClient',
     'BitwardenPasswordlessVerifiedUser',
     'BitwardenRegisterConfig',
+    'register_button',
+    'sign_in_button',
     # components
     'ICON_ERROR',
     'ICON_SUCCESS',

--- a/src/streamlit_passwordless/bitwarden_passwordless/__init__.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/__init__.py
@@ -3,6 +3,7 @@ r"""The Bitwarden Passwordless package."""
 # Local
 from .backend import BitwardenPasswordlessVerifiedUser, BitwardenRegisterConfig
 from .client import BitwardenPasswordlessClient
+from .frontend import register_button, sign_in_button
 
 # The Public API
 
@@ -10,4 +11,6 @@ __all__ = [
     'BitwardenPasswordlessVerifiedUser',
     'BitwardenRegisterConfig',
     'BitwardenPasswordlessClient',
+    'register_button',
+    'sign_in_button',
 ]

--- a/src/streamlit_passwordless/bitwarden_passwordless/client.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/client.py
@@ -50,6 +50,26 @@ class BitwardenPasswordlessClient(models.BaseModel):
             private_key=self.private_key, url=str(self.url)
         )
 
+    def create_register_token(self, user: models.User) -> str:
+        r"""Create a register token to use for registering a passkey with the user's device.
+
+        Parameters
+        ----------
+        user : streamlit_passwordless.User
+            The user to register.
+
+        Returns
+        -------
+        str
+            The register token.
+        """
+
+        return backend._create_register_token(
+            client=self._backend_client,
+            user=user,
+            register_config=self.register_config,  # type: ignore
+        )
+
     def register_user(self, user: models.User, key: str = 'register_user') -> None:
         r"""Register a new user by creating and registring a passkey with the user's device.
 

--- a/src/streamlit_passwordless/bitwarden_passwordless/client.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/client.py
@@ -62,6 +62,12 @@ class BitwardenPasswordlessClient(models.BaseModel):
         -------
         str
             The register token.
+
+        Raises
+        ------
+        streamlit_passwordless.RegisterUserError
+            If an error occurs while trying to create the register token
+            using the Bitwarden Passwordless backend API.
         """
 
         return backend._create_register_token(

--- a/src/streamlit_passwordless/bitwarden_passwordless/client.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/client.py
@@ -10,7 +10,7 @@ from pydantic import AnyHttpUrl, Field, PrivateAttr
 # Local
 from streamlit_passwordless import models
 
-from . import backend, frontend
+from . import backend
 
 logger = logging.getLogger(__name__)
 
@@ -68,93 +68,6 @@ class BitwardenPasswordlessClient(models.BaseModel):
             client=self._backend_client,
             user=user,
             register_config=self.register_config,  # type: ignore
-        )
-
-    def register_user(self, user: models.User, key: str = 'register_user') -> None:
-        r"""Register a new user by creating and registring a passkey with the user's device.
-
-        The result from the method is saved to the session state with a key defined by
-        the `key` parameter. The type of the result is listed in the section `Returns`.
-
-        Parameters
-        ----------
-        user : streamlit_passwordless.User
-            The user to register.
-
-        key : str, default 'register_user'
-            The name of the session state key where the result from the method is saved.
-
-        Returns
-        -------
-        token : str
-            The public key of the created passkey, which the user will use for future sign-in
-            operations. This key is saved to the Bitwarden Passwordless database.
-
-        error : dict
-            An error object containing information about if the registration process was
-            successful or not.
-        """
-
-        register_token = backend._create_register_token(
-            client=self._backend_client,
-            user=user,
-            register_config=self.register_config,  # type: ignore
-        )
-        frontend._register(
-            register_token=register_token,
-            public_key=self.public_key,
-            credential_nickname=user.username,
-            key=key,
-        )
-
-    def sign_in(
-        self,
-        alias: str | None = None,
-        with_discoverable: bool = True,
-        with_autofill: bool = False,
-        key: str = 'sign_in',
-    ) -> None:
-        r"""Start the sign in process the web browser.
-
-        The result from the method is saved to the session state with a key defined by
-        the `key` parameter. The type of the result is listed in the section `Returns`.
-
-        Parameters
-        ----------
-        alias : str or None, default None
-            The alias of the user to sign in. If specified it will override the other sign in
-            methods `with_discoverable`, and `with_autofill`.
-
-        with_discoverable : bool, default True
-            If True the browser's native UI prompt will be used to select the passkey to use for
-            signing in. If False the sign in method is disabled. If True it will override the
-            value of the `with_autofill` parameter. If `alias` is specified it will override this
-            sign in method.
-
-        with_autofill : bool, default False
-            If True the browser's native autofill UI will be used to select the passkey to use for
-            signing in. If False the sign in method is disabled. This method of signing in is
-            overridden if `alias` is specified or `with_discoverable` is True.
-
-        key : str, default 'sign_in'
-            The name of the session state key where the result from the method is saved.
-
-        Returns
-        -------
-        token : str
-            The verification token to be used by the Bitwarden Passwordless backend to authenticate
-            the sign in process.
-
-        error : dict | None
-            An error object containing information if there was an error with the sign in process.
-        """
-
-        frontend._sign_in(
-            public_key=self.public_key,
-            alias=alias,
-            with_discoverable=with_discoverable,
-            with_autofill=with_autofill,
-            key=key,
         )
 
     def verify_sign_in(self, token: str) -> backend.BitwardenPasswordlessVerifiedUser:

--- a/src/streamlit_passwordless/bitwarden_passwordless/frontend.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/frontend.py
@@ -4,6 +4,7 @@ r"""Components related to the frontend library of Bitwarden Passwordless."""
 from pathlib import Path
 
 # Third party
+import streamlit as st
 import streamlit.components.v1 as components
 
 _RELEASE = True
@@ -24,7 +25,7 @@ def register_button(
     credential_nickname: str,
     disabled: bool = False,
     key: str | None = None,
-) -> tuple[str, dict | None]:
+) -> tuple[str, dict | None, bool]:
     r"""Render the register button, which starts the register process when clicked.
 
     The register process creates and registers a passkey with the user's device.
@@ -63,6 +64,9 @@ def register_button(
         An error object containing information about if the registration process was successful
         or not. None is returned if no errors occurred during the register process or if the
         button has not been clicked.
+
+    clicked : bool
+        True if the button was clicked and False otherwise.
     """
 
     value = _bitwarden_passwordless_func(
@@ -75,10 +79,14 @@ def register_button(
     )
 
     if value is None:
-        return '', None
+        return '', None, False
     else:
-        token, error = value
-        return token, error
+        token, error, nr_clicks = value
+        session_state_key = f'_{key}-nr-clicks'
+        clicked = False if st.session_state.get(session_state_key, 0) == nr_clicks else True
+        st.session_state[session_state_key] = nr_clicks
+
+        return token, error, clicked
 
 
 def sign_in_button(
@@ -88,7 +96,7 @@ def sign_in_button(
     with_autofill: bool = False,
     disabled: bool = False,
     key: str | None = None,
-) -> tuple[str, dict | None]:
+) -> tuple[str, dict | None, bool]:
     r"""Render the sign in button, which starts the sign in process when clicked.
 
     Uses the Bitwarden Passwordless javascript frontend client.
@@ -134,6 +142,9 @@ def sign_in_button(
         An error object containing information if there was an error with the sign in process.
         None is returned if no errors occurred during the sign in process or if the button
         has not been clicked.
+
+    clicked : bool
+        True if the button was clicked and False otherwise.
     """
 
     value = _bitwarden_passwordless_func(
@@ -147,7 +158,11 @@ def sign_in_button(
     )
 
     if value is None:
-        return '', None
+        return '', None, False
     else:
-        token, error = value
-        return token, error
+        token, error, nr_clicks = value
+        session_state_key = f'_{key}-nr-clicks'
+        clicked = False if st.session_state.get(session_state_key, 0) == nr_clicks else True
+        st.session_state[session_state_key] = nr_clicks
+
+        return token, error, clicked

--- a/src/streamlit_passwordless/bitwarden_passwordless/frontend.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/frontend.py
@@ -18,13 +18,19 @@ else:
     _bitwarden_passwordless_func = components.declare_component(name=_COMPONENT_NAME, url=_DEV_URL)
 
 
-def _register(
-    register_token: str, public_key: str, credential_nickname: str, key: str | None = None
-) -> None:
-    r"""Register a new user by creating and registring a passkey with the user's device.
+def register_button(
+    register_token: str,
+    public_key: str,
+    credential_nickname: str,
+    disabled: bool = False,
+    key: str | None = None,
+) -> tuple[str, dict | None]:
+    r"""Render the register button, which starts the register process when clicked.
 
-    The return value from the javascript function is saved to the session state with a key
-    defined by the `key` parameter. The type of the result is listed in the section `Returns`.
+    The register process creates and registers a passkey with the user's device.
+
+    The return value from the button is also saved to the session state with a key
+    defined by the `key` parameter if `key` is not None.
 
     Parameters
     ----------
@@ -38,6 +44,9 @@ def _register(
         A nickname for the passkey credential being registered to use for easier identification
         of the device being registered.
 
+    disabled : bool, default False
+        If True the button will be disabled and if False the button will be clickable.
+
     key : str or None, default None
         An optional key that uniquely identifies this component. If this is None, and the
         component's arguments are changed, the component will be re-mounted in the Streamlit
@@ -47,35 +56,45 @@ def _register(
     -------
     token : str
         The public key of the created passkey, which the user will use for future sign-in
-        operations. This key is saved to the Bitwarden Passwordless database.
+        operations. This key is saved to the Bitwarden Passwordless database. An empty string
+        is returned if the button has not been clicked.
 
     error : dict
-        An error object containing information about if the registration process was
-        successful or not.
+        An error object containing information about if the registration process was successful
+        or not. None is returned if no errors occurred during the register process or if the
+        button has not been clicked.
     """
 
-    _bitwarden_passwordless_func(
+    value = _bitwarden_passwordless_func(
         action='register',
         register_token=register_token,
         public_key=public_key,
         credential_nickname=credential_nickname,
+        disabled=disabled,
         key=key,
     )
 
+    if value is None:
+        return '', None
+    else:
+        token, error = value
+        return token, error
 
-def _sign_in(
+
+def sign_in_button(
     public_key: str,
     alias: str | None = None,
     with_discoverable: bool = True,
     with_autofill: bool = False,
+    disabled: bool = False,
     key: str | None = None,
-) -> None:
-    r"""Start the sign in process the web browser.
+) -> tuple[str, dict | None]:
+    r"""Render the sign in button, which starts the sign in process when clicked.
 
     Uses the Bitwarden Passwordless javascript frontend client.
 
-    The return value from the javascript function is saved to the session state with a key
-    defined by the `key` parameter. The type of the result is listed in the section `Returns`.
+    The return value from the button is also saved to the session state with a key
+    defined by the `key` parameter if key is not None.
 
     Parameters
     ----------
@@ -97,6 +116,9 @@ def _sign_in(
         signing in. If False the sign in method is disabled. This method of signing in is
         overridden if `alias` is specified or `with_discoverable` is True.
 
+    disabled : bool, default False
+        If True the button will be disabled and if False the button will be clickable.
+
     key : str or None, default None
         An optional key that uniquely identifies this component. If this is None, and the
         component's arguments are changed, the component will be re-mounted in the Streamlit
@@ -106,17 +128,26 @@ def _sign_in(
     -------
     token : str
         The verification token to be used by the Bitwarden Passwordless backend to authenticate
-        the sign in process.
+        the sign in process. An empty string is returned if the button has not been clicked.
 
     error : dict | None
         An error object containing information if there was an error with the sign in process.
+        None is returned if no errors occurred during the sign in process or if the button
+        has not been clicked.
     """
 
-    _bitwarden_passwordless_func(
+    value = _bitwarden_passwordless_func(
         action='sign_in',
         public_key=public_key,
         alias=alias,
         with_discoverable=with_discoverable,
         with_autofill=with_autofill,
+        disabled=disabled,
         key=key,
     )
+
+    if value is None:
+        return '', None
+    else:
+        token, error = value
+        return token, error

--- a/src/streamlit_passwordless/bitwarden_passwordless/frontend/package.json
+++ b/src/streamlit_passwordless/bitwarden_passwordless/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden_passwordless",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "dependencies": {
     "@passwordlessdev/passwordless-client": "1.1.2",

--- a/src/streamlit_passwordless/bitwarden_passwordless/frontend/package.json
+++ b/src/streamlit_passwordless/bitwarden_passwordless/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden_passwordless",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "dependencies": {
     "@passwordlessdev/passwordless-client": "1.1.2",

--- a/src/streamlit_passwordless/bitwarden_passwordless/frontend/src/index.tsx
+++ b/src/streamlit_passwordless/bitwarden_passwordless/frontend/src/index.tsx
@@ -10,6 +10,7 @@ const button = document.body.appendChild(document.createElement("button"));
 let action: string; // 'register' or 'sign_in'
 let disabled: boolean;
 let passwordlessClient: Client;
+let buttonNrClicks: number = 0;
 
 // register
 let registerToken: string;
@@ -105,14 +106,15 @@ async function sign_in(client: Client, alias: string, withDiscoverable: boolean,
  */
 async function registerOnClick () {
 
+  buttonNrClicks += 1;
   register(passwordlessClient, registerToken, credentialNickname).then(
     ([token, error])=>{
-      Streamlit.setComponentValue([token, error]);
+      Streamlit.setComponentValue([token, error, buttonNrClicks]);
     }
   ).catch(
     (error)=>{
       console.log('Error registring passkey credential', error);
-      Streamlit.setComponentValue([undefined, error]);
+      Streamlit.setComponentValue([undefined, error, buttonNrClicks]);
     }
   )
 }
@@ -122,14 +124,15 @@ async function registerOnClick () {
  */
 async function signInOnClick() {
 
+  buttonNrClicks += 1;
   sign_in(passwordlessClient, alias, withDiscoverable, withAutofill).then(
     ([token, error])=>{
-      Streamlit.setComponentValue([token, error]);
+      Streamlit.setComponentValue([token, error, buttonNrClicks]);
     }
   ).catch(
     (error)=>{
       console.log('Error signing in', error);
-      Streamlit.setComponentValue([undefined, error]);
+      Streamlit.setComponentValue([undefined, error, buttonNrClicks]);
     }
   )
 }
@@ -185,7 +188,7 @@ function onRender(event: Event): void {
          'from': 'client',
        };
         console.log('Error : Invalid action', error);
-        Streamlit.setComponentValue([undefined, error]);
+        Streamlit.setComponentValue([undefined, error, -1]);
   }
 
   // We tell Streamlit to update our frameHeight after each render event, in

--- a/src/streamlit_passwordless/components/ids.py
+++ b/src/streamlit_passwordless/components/ids.py
@@ -13,5 +13,5 @@ BP_REGISTER_FORM_SUBMIT_BUTTON = 'bp-register-form-submit-button'
 # Sign in form
 # =====================================================================================
 
-BP_SIGN_IN_FORM = 'bp-sign-in-form'
 BP_SIGN_IN_FORM_ALIAS_TEXT_INPUT = 'bp-sign-in-form-alias-text-input'
+BP_SIGN_IN_FORM_SUBMIT_BUTTON = 'bp-sign-in-form-submit-button'

--- a/src/streamlit_passwordless/components/ids.py
+++ b/src/streamlit_passwordless/components/ids.py
@@ -4,7 +4,6 @@ r"""The ID:s of components used for identification and session state management.
 # Register form
 # =====================================================================================
 
-BP_REGISTER_FORM = 'bp-register-form'
 BP_REGISTER_FORM_USERNAME_TEXT_INPUT = 'bp-register-form-username-text-input'
 BP_REGISTER_FORM_DISPLAYNAME_TEXT_INPUT = 'bp-register-form-displayname-text-input'
 BP_REGISTER_FORM_ALIASES_TEXT_INPUT = 'bp-register-form-aliases-text-input'

--- a/src/streamlit_passwordless/components/ids.py
+++ b/src/streamlit_passwordless/components/ids.py
@@ -8,6 +8,7 @@ BP_REGISTER_FORM = 'bp-register-form'
 BP_REGISTER_FORM_USERNAME_TEXT_INPUT = 'bp-register-form-username-text-input'
 BP_REGISTER_FORM_DISPLAYNAME_TEXT_INPUT = 'bp-register-form-displayname-text-input'
 BP_REGISTER_FORM_ALIASES_TEXT_INPUT = 'bp-register-form-aliases-text-input'
+BP_REGISTER_FORM_SUBMIT_BUTTON = 'bp-register-form-submit-button'
 
 # =====================================================================================
 # Sign in form

--- a/src/streamlit_passwordless/components/register_form.py
+++ b/src/streamlit_passwordless/components/register_form.py
@@ -7,7 +7,7 @@ from typing import Literal
 # Third party
 import streamlit as st
 
-from streamlit_passwordless import exceptions, models
+from streamlit_passwordless import exceptions, models, register_button
 from streamlit_passwordless.bitwarden_passwordless.client import BitwardenPasswordlessClient
 
 # Local
@@ -16,43 +16,57 @@ from . import config, ids
 logger = logging.getLogger(__name__)
 
 
-def _validate_form() -> None:
-    r"""Validate the input to the registration form and create the user to register.
+def _validate_username() -> None:
+    r"""Validate the input username."""
 
-    The created user is saved to the session state with the key `config.SK_BP_USER_TO_REGISTER`.
-
-    Session state
-    -------------
-    config.SK_BP_USER_TO_REGISTER : models.User | None
-        The user to register. None is returned if a user
-        could not be created from the form data.
-    """
-
-    error_msg = ''
     username = st.session_state[ids.BP_REGISTER_FORM_USERNAME_TEXT_INPUT]
-    displayname = st.session_state[ids.BP_REGISTER_FORM_DISPLAYNAME_TEXT_INPUT]
-    aliases = st.session_state[ids.BP_REGISTER_FORM_ALIASES_TEXT_INPUT]
-
     if not username:
         error_msg = 'The username field is required!'
         logger.error(error_msg)
-
-    # Create a user
-    if not error_msg:
-        try:
-            st.session_state[config.SK_BP_USER_TO_REGISTER] = models.User(
-                username=username, displayname=displayname, aliases=aliases
-            )
-        except exceptions.StreamlitPasswordlessError as e:
-            error_msg = str(e)
-            logger.error(error_msg)
-
-    if error_msg:
         st.error(error_msg, icon=config.ICON_ERROR)
-        st.session_state[config.SK_BP_REGISTER_FROM_IS_VALID] = False
-        st.session_state[config.SK_BP_USER_TO_REGISTER] = None
+
+
+def _create_user(
+    username: str, displayname: str | None = None, aliases: str | None = None
+) -> tuple[models.User | None, str]:
+    r"""Create a new user to register.
+
+    The created user is also saved to the session state
+    with the key `config.SK_BP_USER_TO_REGISTER`.
+
+    Parameters
+    ----------
+    username : str
+        The username.
+
+    displayname : str or None, default None
+        The optional displayname of the user.
+
+    aliases : str | None, default None
+        The optional aliases of the user as a semicolon separated string.
+
+    Returns
+    -------
+    user : models.User or None
+        The user to create. None is returned if an error occurred while creating the user.
+
+    error_msg : str
+        The error message if a user could not be created successfully. If no errors an empty
+        string is returned.
+    """
+
+    error_msg = ''
+    try:
+        user = models.User(username=username, displayname=displayname, aliases=aliases)
+    except exceptions.StreamlitPasswordlessError as e:
+        error_msg = str(e)
+        logger.error(error_msg)
+        user = None
     else:
-        st.session_state[config.SK_BP_REGISTER_FROM_IS_VALID] = True
+        logger.debug(f'Successfully created user: {user}')
+
+    st.session_state[config.SK_BP_USER_TO_REGISTER] = user
+    return user, error_msg
 
 
 def bitwarden_register_form(
@@ -60,8 +74,8 @@ def bitwarden_register_form(
     is_admin: bool = False,
     pre_authorized: bool = True,
     title: str = '#### Register a new passkey with your device.',
-    clear_on_submit: bool = False,
     submit_button_label: str = 'Register',
+    border: bool = True,
     button_type: Literal['primary', 'secondary'] = 'primary',
 ) -> None:
     r"""Render the Bitwarden Passwordless register form.
@@ -91,59 +105,79 @@ def bitwarden_register_form(
     submit_button_label : str, default 'Register'
         The label of the submit button.
 
+    border : bool, default True
+        If True a border will be rendered around the form.
+
     button_type : Literal['primary', 'secondary'], default 'primary'
         The styling of the submit button.
     """
 
+    user = None
+    register_token = ''
+    error_msg = ''
     banner_container = st.empty()
 
-    with st.form(key=ids.BP_REGISTER_FORM, clear_on_submit=clear_on_submit):
+    with st.container(border=border):
         st.markdown(title)
-        st.text_input(
+        username = st.text_input(
             label='Username',
             placeholder='syn.gates@ax7.com',
             help='A unique identifier for the account. E.g. an email address.',
+            on_change=_validate_username,
             key=ids.BP_REGISTER_FORM_USERNAME_TEXT_INPUT,
         )
-        st.text_input(
+        disabled = False if username else True
+        displayname = st.text_input(
             label='Displayname',
             placeholder='Synyster Gates',
             help='A descriptive name of the user.',
             key=ids.BP_REGISTER_FORM_DISPLAYNAME_TEXT_INPUT,
+            disabled=disabled,
         )
-        st.text_input(
+        aliases = st.text_input(
             label='Alias',
             placeholder='syn;gates;afterlife',
             key=ids.BP_REGISTER_FORM_ALIASES_TEXT_INPUT,
+            disabled=disabled,
             help=(
                 'One or more aliases that can be used to sign in to the account. '
                 'Aliases are separated by semicolon (";"). The username is always '
-                'added as an alias.'
+                'added as an alias. An alias must be unique across all users.'
             ),
         )
 
-        form_submit_button = st.form_submit_button(
-            label=submit_button_label,
-            type=button_type,
-            on_click=_validate_form,
+        if username:
+            user, error_msg = _create_user(
+                username=username, displayname=displayname, aliases=aliases
+            )
+            if user is not None:
+                register_token = client.create_register_token(user=user)
+
+        token, error = register_button(
+            register_token=register_token,
+            public_key=client.public_key,
+            credential_nickname=username,
+            disabled=disabled,
+            key=ids.BP_REGISTER_FORM_SUBMIT_BUTTON,
         )
 
-    user = st.session_state[config.SK_BP_USER_TO_REGISTER]
+    if disabled:
+        return
 
-    if form_submit_button and st.session_state[config.SK_BP_REGISTER_FROM_IS_VALID]:
-        client.register_user(user=user, key=config.SK_BP_REGISTER_USER_RESULT)
+    if error_msg:
+        with banner_container:
+            st.error(error_msg, icon=config.ICON_ERROR)
+        return
 
-    if (register_result := st.session_state[config.SK_BP_REGISTER_USER_RESULT]) is not None:
-        _, error = register_result
-        if error:
-            error_msg = f'Error creating passkey for user ({user})!\nerror : {error}'
-            logger.error(error_msg)
-            with banner_container:
-                st.error(error_msg, icon=config.ICON_ERROR)
-            return
-        else:
-            msg = f'Successfully registered user: {user.username}!'
-            logger.info(msg)
-            with banner_container:
-                st.success(msg, icon=config.ICON_SUCCESS)
-        # Save user to database
+    if not token and error:
+        error_msg = f'Error creating passkey for user ({user})!\nerror : {error}'
+        logger.error(error_msg)
+        with banner_container:
+            st.error(error_msg, icon=config.ICON_ERROR)
+        return
+
+    if token and username:
+        msg = f'Successfully registered user: {user.username}!'
+        logger.info(msg)
+        with banner_container:
+            st.success(msg, icon=config.ICON_SUCCESS)

--- a/tests/test_bitwarden_passwordless/test_client.py
+++ b/tests/test_bitwarden_passwordless/test_client.py
@@ -6,12 +6,11 @@ from unittest.mock import Mock
 
 # Third party
 import pytest
-from passwordless import PasswordlessError
 from pydantic import AnyHttpUrl
 
 # Local
 import streamlit_passwordless.bitwarden_passwordless.client
-from streamlit_passwordless import exceptions, models
+from streamlit_passwordless import exceptions
 from streamlit_passwordless.bitwarden_passwordless.client import (
     BitwardenPasswordlessClient,
     backend,
@@ -178,96 +177,6 @@ class TestBitwardenPasswordlessClient:
         print(error_msg)
 
         assert 'authenticator_type' in error_msg, 'authenticator_type not in error message!'
-
-        # Clean up - None
-        # ===========================================================
-
-
-class TestRegisterMethod:
-    r"""Tests for the method `BitwardenPasswordlessClient.register_user`."""
-
-    @pytest.mark.raises
-    def test_backend_raises_register_user_error(
-        self, user: models.User, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        r"""Test that `exceptions.RegisterUserError` can be properly raised.
-
-        The Bitwarden Passwordless backend client should raise `passwordless.PasswordlessError`
-        which should be re-raised as `exceptions.RegisterUserError` by the function
-        `bitwarden_passwordless.backend._create_register_token`.
-        """
-
-        # Setup
-        # ===========================================================
-        client = BitwardenPasswordlessClient(
-            url='https://ax7.com', private_key='public key', public_key='private key'
-        )
-        problem_details = {'error': True}
-
-        monkeypatch.setattr(
-            client._backend_client,
-            'register_token',
-            Mock(side_effect=PasswordlessError(problem_details=problem_details)),
-        )
-
-        # Exercise
-        # ===========================================================
-        with pytest.raises(exceptions.RegisterUserError) as exc_info:
-            client.register_user(user=user)
-
-        # Verify
-        # ===========================================================
-        error_msg = exc_info.exconly()
-        print(error_msg)
-
-        assert exc_info.value.data['problem_details'] == problem_details
-
-        # Clean up - None
-        # ===========================================================
-
-
-class TestSignInMethod:
-    r"""Tests for the method `BitwardenPasswordlessClient.sign_in`."""
-
-    def test_called_correctly(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        r"""Test that the `sign_in` method can be called correctly."""
-
-        # Setup
-        # ===========================================================
-        alias = 'syn.gates'
-        with_discoverable = True
-        with_autofill = False
-        key = 'key'
-        public_key = 'public_key'
-
-        client = BitwardenPasswordlessClient(
-            url='https://ax7.com', private_key='private key', public_key=public_key
-        )
-
-        m = Mock(
-            spec_set=streamlit_passwordless.bitwarden_passwordless.client.frontend._sign_in,
-            name='mocked__sign_in_function',
-        )
-
-        monkeypatch.setattr(
-            streamlit_passwordless.bitwarden_passwordless.client.frontend, '_sign_in', m
-        )
-
-        # Exercise
-        # ===========================================================
-        client.sign_in(
-            alias=alias, with_discoverable=with_discoverable, with_autofill=with_autofill, key=key
-        )
-
-        # Verify
-        # ===========================================================
-        m.assert_called_once_with(
-            public_key=public_key,
-            alias=alias,
-            with_discoverable=with_discoverable,
-            with_autofill=with_autofill,
-            key=key,
-        )
 
         # Clean up - None
         # ===========================================================

--- a/tests/test_bitwarden_passwordless/test_frontend.py
+++ b/tests/test_bitwarden_passwordless/test_frontend.py
@@ -1,0 +1,133 @@
+r"""Unit tests for the frontend module of the bitwarden_passwordless library."""
+
+# Standard library
+from unittest.mock import Mock
+
+# Third party
+import pytest
+
+# Local
+import streamlit_passwordless.bitwarden_passwordless.frontend
+from streamlit_passwordless.bitwarden_passwordless.frontend import (
+    _bitwarden_passwordless_func,
+    register_button,
+    sign_in_button,
+)
+
+# =============================================================================================
+# Tests
+# =============================================================================================
+
+
+class TestRegisterButton:
+    r"""Tests for the function `register_button`."""
+
+    def test_called_correctly(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        r"""Test that the `register_button` function can be called correctly."""
+
+        # Setup
+        # ===========================================================
+        register_token = 'register_token'
+        public_key = 'public_key'
+        credential_nickname = 'credential_nickname'
+        disabled = True
+        key = 'key'
+        return_value = ('token', None, 1)
+
+        m = Mock(
+            spec_set=_bitwarden_passwordless_func,
+            return_value=return_value,
+            name='mocked_javascript_func',
+        )
+
+        monkeypatch.setattr(
+            streamlit_passwordless.bitwarden_passwordless.frontend,
+            '_bitwarden_passwordless_func',
+            m,
+        )
+
+        # Exercise
+        # ===========================================================
+        token, error, clicked = register_button(
+            register_token=register_token,
+            public_key=public_key,
+            credential_nickname=credential_nickname,
+            disabled=disabled,
+            key=key,
+        )
+
+        # Verify
+        # ===========================================================
+        m.assert_called_once_with(
+            action='register',
+            register_token=register_token,
+            public_key=public_key,
+            credential_nickname=credential_nickname,
+            disabled=disabled,
+            key=key,
+        )
+        assert token == return_value[0], 'token is incorrect!'
+        assert error == return_value[1], 'error is incorrect!'
+        assert clicked is True, 'clicked is incorrect!'
+
+        # Clean up - None
+        # ===========================================================
+
+
+class TestSignInButton:
+    r"""Tests for the function `sign_in_button`."""
+
+    def test_called_correctly(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        r"""Test that the `sign_in_button` function can be called correctly."""
+
+        # Setup
+        # ===========================================================
+        public_key = 'public_key'
+        alias = 'syn.gates'
+        with_discoverable = True
+        with_autofill = False
+        disabled = False
+        key = 'key'
+
+        return_value = ('token', None, 1)
+
+        m = Mock(
+            spec_set=_bitwarden_passwordless_func,
+            return_value=return_value,
+            name='mocked_javascript_func',
+        )
+
+        monkeypatch.setattr(
+            streamlit_passwordless.bitwarden_passwordless.frontend,
+            '_bitwarden_passwordless_func',
+            m,
+        )
+
+        # Exercise
+        # ===========================================================
+        token, error, clicked = sign_in_button(
+            public_key=public_key,
+            alias=alias,
+            with_discoverable=with_discoverable,
+            with_autofill=with_autofill,
+            disabled=disabled,
+            key=key,
+        )
+
+        # Verify
+        # ===========================================================
+        m.assert_called_once_with(
+            action='sign_in',
+            public_key=public_key,
+            alias=alias,
+            with_discoverable=with_discoverable,
+            with_autofill=with_autofill,
+            disabled=disabled,
+            key=key,
+        )
+        assert token == return_value[0], 'token is incorrect!'
+        assert error == return_value[1], 'error is incorrect!'
+        assert clicked is True, 'clicked is incorrect!'
+
+        # Clean up - None
+        # ===========================================================


### PR DESCRIPTION
Redesigning the register and sign in form to use submit buttons rendered from the javascript custom component. Triggering the register and sign in workflow by pressing these buttons should resolve the "Document is not focused" error that occurs on iPhones by being closer to the document than a button rendered from the "Streamlit side".