### PR TITLE
Adding styling of register and sign in buttons

### DIFF
--- a/src/streamlit_passwordless/bitwarden_passwordless/frontend.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/frontend.py
@@ -2,6 +2,7 @@ r"""Components related to the frontend library of Bitwarden Passwordless."""
 
 # Standard library
 from pathlib import Path
+from typing import Literal
 
 # Third party
 import streamlit as st
@@ -24,6 +25,8 @@ def register_button(
     public_key: str,
     credential_nickname: str,
     disabled: bool = False,
+    label: str = 'Register',
+    button_type: Literal['primary', 'secondary'] = 'primary',
     key: str | None = None,
 ) -> tuple[str, dict | None, bool]:
     r"""Render the register button, which starts the register process when clicked.
@@ -47,6 +50,12 @@ def register_button(
 
     disabled : bool, default False
         If True the button will be disabled and if False the button will be clickable.
+
+    label : str, default 'Register'
+        The label of the button.
+
+    button_type : Literal['primary', 'secondary'], default 'primary'
+        The styling of the button. Emulates the `type` parameter of :func:`streamlit.button`.
 
     key : str or None, default None
         An optional key that uniquely identifies this component. If this is None, and the
@@ -75,6 +84,8 @@ def register_button(
         public_key=public_key,
         credential_nickname=credential_nickname,
         disabled=disabled,
+        label=label,
+        button_type=button_type,
         key=key,
     )
 
@@ -95,6 +106,8 @@ def sign_in_button(
     with_discoverable: bool = True,
     with_autofill: bool = False,
     disabled: bool = False,
+    label: str = 'Sign in',
+    button_type: Literal['primary', 'secondary'] = 'primary',
     key: str | None = None,
 ) -> tuple[str, dict | None, bool]:
     r"""Render the sign in button, which starts the sign in process when clicked.
@@ -127,6 +140,12 @@ def sign_in_button(
     disabled : bool, default False
         If True the button will be disabled and if False the button will be clickable.
 
+    label : str, default 'Register'
+        The label of the button.
+
+    button_type : Literal['primary', 'secondary'], default 'primary'
+        The styling of the button. Emulates the `type` parameter of :func:`streamlit.button`.
+
     key : str or None, default None
         An optional key that uniquely identifies this component. If this is None, and the
         component's arguments are changed, the component will be re-mounted in the Streamlit
@@ -154,6 +173,8 @@ def sign_in_button(
         with_discoverable=with_discoverable,
         with_autofill=with_autofill,
         disabled=disabled,
+        label=label,
+        button_type=button_type,
         key=key,
     )
 

--- a/src/streamlit_passwordless/bitwarden_passwordless/frontend/package.json
+++ b/src/streamlit_passwordless/bitwarden_passwordless/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden_passwordless",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "dependencies": {
     "@passwordlessdev/passwordless-client": "1.1.2",

--- a/src/streamlit_passwordless/bitwarden_passwordless/frontend/public/button.css
+++ b/src/streamlit_passwordless/bitwarden_passwordless/frontend/public/button.css
@@ -1,0 +1,68 @@
+button {
+        display: inline-flex;
+        -moz-box-align: center;
+        align-items: center;
+        -moz-box-pack: center;
+        justify-content: center;
+        font-weight: 400;
+        padding: 0.25rem 0.75rem;
+        border-radius: 0.5rem;
+        min-height: 38.4px;
+        margin: 0px;
+        line-height: 1.6;
+        width: auto;
+        user-select: none;
+        background-color: var(--primary-color);
+        color: var(--text-color);
+        border: 1px solid var(--primary-color);
+        font-family: "Source Sans Pro", sans-serif;
+        font: var(--font);
+}
+
+button.primary {
+    background-color: var(--primary-color);
+}
+
+button.secondary {
+    background-color: var(--background-color);
+    border: 1px solid rgba(250, 250, 250, 0.2);
+}
+
+button:active {
+    background-color: transparent;
+    color: var(--primary-color);
+}
+
+button:focus {
+    outline: none;
+}
+
+button:focus-visible {
+    box-shadow: rgba(255, 75, 75, 0.5) 0px 0px 0px 0.2rem;
+}
+
+button:hover {
+    cursor: pointer;
+}
+
+button.secondary:hover {
+    border-color: var(--primary-color);
+    color: var(--primary-color);
+}
+
+button.secondary:active {
+    background-color: var(--primary-color);
+    border-color: var(--primary-color);
+    color: var(--text-color);
+}
+
+button:not(:disabled) {
+    cursor: pointer;
+}
+
+button:disabled {
+    border-color: rgba(250, 250, 250, 0.2);
+    background-color: transparent;
+    color: rgba(250, 250, 250, 0.4);
+    cursor: not-allowed;
+}

--- a/src/streamlit_passwordless/bitwarden_passwordless/frontend/public/button.css
+++ b/src/streamlit_passwordless/bitwarden_passwordless/frontend/public/button.css
@@ -28,7 +28,7 @@ button.secondary {
     border: 1px solid rgba(250, 250, 250, 0.2);
 }
 
-button:active {
+button:active:enabled {
     background-color: transparent;
     color: var(--primary-color);
 }
@@ -41,16 +41,16 @@ button:focus-visible {
     box-shadow: rgba(255, 75, 75, 0.5) 0px 0px 0px 0.2rem;
 }
 
-button:hover {
+button:hover:enabled {
     cursor: pointer;
 }
 
-button.secondary:hover {
+button.secondary:hover:enabled {
     border-color: var(--primary-color);
     color: var(--primary-color);
 }
 
-button.secondary:active {
+button.secondary:active:enabled {
     background-color: var(--primary-color);
     border-color: var(--primary-color);
     color: var(--text-color);

--- a/src/streamlit_passwordless/bitwarden_passwordless/frontend/public/index.html
+++ b/src/streamlit_passwordless/bitwarden_passwordless/frontend/public/index.html
@@ -7,6 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Streamlit Component" />
     <link rel="stylesheet" href="bootstrap.min.css" />
+    <link rel="stylesheet" href="button.css" />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/streamlit_passwordless/bitwarden_passwordless/frontend/src/index.tsx
+++ b/src/streamlit_passwordless/bitwarden_passwordless/frontend/src/index.tsx
@@ -7,8 +7,6 @@ const button = document.body.appendChild(document.createElement("button"));
 // Global variables
 
 // common
-let action: string; // 'register' or 'sign_in'
-let disabled: boolean;
 let passwordlessClient: Client;
 let buttonNrClicks: number = 0;
 
@@ -104,7 +102,7 @@ async function sign_in(client: Client, alias: string, withDiscoverable: boolean,
 /**
  * The callback function to be triggered when the register button is clicked.
  */
-async function registerOnClick () {
+function registerOnClick () {
 
   buttonNrClicks += 1;
   register(passwordlessClient, registerToken, credentialNickname).then(
@@ -122,7 +120,7 @@ async function registerOnClick () {
 /**
  * The callback function to be triggered when the sign_in button is clicked.
  */
-async function signInOnClick() {
+function signInOnClick() {
 
   buttonNrClicks += 1;
   sign_in(passwordlessClient, alias, withDiscoverable, withAutofill).then(
@@ -146,15 +144,19 @@ function onRender(event: Event): void {
   // Get the RenderData from the event
   const data = (event as CustomEvent<RenderData>).detail;
 
-  action = data.args['action'];
-  disabled = data.args['disabled'];
   const apiKey: string = data.args['public_key'];
+  const action: string = data.args['action'];
+  const disabled: boolean = data.args['disabled'];
+  const button_type: string = data.args['button_type'];
+  const button_label: string = data.args['label'];
 
   createPasswordlessClient(apiKey);
   console.log('passwordlessClient', passwordlessClient);
   console.log('isSecureContext', window.isSecureContext);
 
   button.disabled = disabled;
+  button.className = button_type === 'primary' ? 'primary' : 'secondary';
+  button.textContent = button_label;
 
   switch (action) {
     case 'register':
@@ -162,7 +164,6 @@ function onRender(event: Event): void {
       registerToken = data.args['register_token'];
       credentialNickname = data.args['credential_nickname'];
 
-      button.textContent = 'Register';
       button.onclick = registerOnClick;
       console.log('button', button)
 
@@ -173,7 +174,6 @@ function onRender(event: Event): void {
       withDiscoverable = data.args['with_discoverable'];
       withAutofill = data.args['with_autofill'];
 
-      button.textContent = 'Sign In';
       button.onclick = signInOnClick;
       console.log('button', button);
 

--- a/src/streamlit_passwordless/components/register_form.py
+++ b/src/streamlit_passwordless/components/register_form.py
@@ -127,7 +127,7 @@ def bitwarden_register_form(
         The label of the submit button.
 
     button_type : Literal['primary', 'secondary'], default 'primary'
-        The styling of the submit button.
+        The styling of the button. Emulates the `type` parameter of :func:`streamlit.button`.
 
     Other Parameters
     ----------------
@@ -253,6 +253,8 @@ def bitwarden_register_form(
             public_key=client.public_key,
             credential_nickname=username,
             disabled=disabled,
+            label=submit_button_label,
+            button_type=button_type,
             key=ids.BP_REGISTER_FORM_SUBMIT_BUTTON,
         )
 

--- a/src/streamlit_passwordless/components/sign_in_form.py
+++ b/src/streamlit_passwordless/components/sign_in_form.py
@@ -68,7 +68,7 @@ def bitwarden_sign_in_form(
         The label of the submit button.
 
     button_type : Literal['primary', 'secondary'], default 'primary'
-        The styling of the submit button.
+        The styling of the button. Emulates the `type` parameter of :func:`streamlit.button`.
 
     Other Parameters
     ----------------
@@ -126,6 +126,8 @@ def bitwarden_sign_in_form(
             alias=st.session_state.get(ids.BP_SIGN_IN_FORM_ALIAS_TEXT_INPUT),
             with_discoverable=with_discoverable,
             with_autofill=with_autofill,
+            label=submit_button_label,
+            button_type=button_type,
             key=ids.BP_SIGN_IN_FORM_SUBMIT_BUTTON,
         )
 


### PR DESCRIPTION
Adding styling of the register and sign in buttons to make them look like buttons created with the function `streamlit.button`. The styling uses the css variables from the Streamlit theme. 

Adding functionality to set the labels of the register and sign in buttons through the parameter `label`. Adding the parameter `button_type`, which allows to switch styling of the buttons between "primary" and "secondary".