### PR TITLE
Updating the register form with database support

### DIFF
--- a/src/streamlit_passwordless/bitwarden_passwordless/client.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/client.py
@@ -50,6 +50,9 @@ class BitwardenPasswordlessClient(models.BaseModel):
             private_key=self.private_key, url=str(self.url)
         )
 
+    def __hash__(self) -> int:
+        return hash(self.private_key + self.public_key)
+
     def create_register_token(self, user: models.User) -> str:
         r"""Create a register token to use for registering a passkey with the user's device.
 

--- a/src/streamlit_passwordless/components/config.py
+++ b/src/streamlit_passwordless/components/config.py
@@ -12,10 +12,9 @@ import streamlit as st
 # Session state keys
 # =====================================================================================
 
-SK_USERNAME_IS_VALID = 'stp-username-is-valid'
 SK_BP_VERIFIED_USER = 'stp-bp-verified-user'
 SK_DB_USER = 'stp-db-user'
-
+SK_REGISTER_FORM_IS_VALID = 'stp-register-form-is-valid'
 
 # =====================================================================================
 # Icons
@@ -36,19 +35,18 @@ def init_session_state() -> None:
 
     Session state keys
     ------------------
-    SK_USERNAME_IS_VALID : bool, default False
-        True if the input username from the user is valid, which allows the user
-        to register a passkey credential. Assumed False until proven otherwise.
-
     SK_BP_VERIFIED_USER : streamlit_passwordless.BitwardenPasswordlessVerifiedUser or None, default None
         A verified user from Bitwarden Passwordless.
 
     SK_DB_USER : streamlit_passwordless.db.models.User or None, default None
         The database user. If None the user does not exist in the database.
+
+    SK_REGISTER_FORM_IS_VALID : bool, default False
+        True if the input to register form is valid and False otherwise.
     """
 
     none_keys = (SK_BP_VERIFIED_USER, SK_DB_USER)
     for key in none_keys:
         st.session_state[key] = None
 
-    st.session_state[SK_USERNAME_IS_VALID] = False
+    st.session_state[SK_REGISTER_FORM_IS_VALID] = False

--- a/src/streamlit_passwordless/components/config.py
+++ b/src/streamlit_passwordless/components/config.py
@@ -12,7 +12,9 @@ import streamlit as st
 # Session state keys
 # =====================================================================================
 
-SK_BP_VERIFIED_USER = 'bp-verified-user'
+SK_USERNAME_IS_VALID = 'stp-username-is-valid'
+SK_BP_VERIFIED_USER = 'stp-bp-verified-user'
+SK_DB_USER = 'stp-db-user'
 
 
 # =====================================================================================
@@ -34,8 +36,19 @@ def init_session_state() -> None:
 
     Session state keys
     ------------------
-    SK_BP_VERIFIED_USER : streamlit_passwordless.BitwardenPasswordlessVerifiedUser | None, default None
+    SK_USERNAME_IS_VALID : bool, default False
+        True if the input username from the user is valid, which allows the user
+        to register a passkey credential. Assumed False until proven otherwise.
+
+    SK_BP_VERIFIED_USER : streamlit_passwordless.BitwardenPasswordlessVerifiedUser or None, default None
         A verified user from Bitwarden Passwordless.
+
+    SK_DB_USER : streamlit_passwordless.db.models.User or None, default None
+        The database user. If None the user does not exist in the database.
     """
 
-    st.session_state[SK_BP_VERIFIED_USER] = None
+    none_keys = (SK_BP_VERIFIED_USER, SK_DB_USER)
+    for key in none_keys:
+        st.session_state[key] = None
+
+    st.session_state[SK_USERNAME_IS_VALID] = False

--- a/src/streamlit_passwordless/components/core.py
+++ b/src/streamlit_passwordless/components/core.py
@@ -1,0 +1,59 @@
+r"""Helper functions and core components that can be used by other components."""
+
+# Standard library
+import logging
+
+# Third party
+import streamlit as st
+
+# Local
+from streamlit_passwordless import exceptions
+from streamlit_passwordless.bitwarden_passwordless.backend import BitwardenPasswordlessVerifiedUser
+from streamlit_passwordless.bitwarden_passwordless.client import BitwardenPasswordlessClient
+
+from . import config
+
+logger = logging.getLogger(__name__)
+
+
+def verify_sign_in(
+    client: BitwardenPasswordlessClient, token: str
+) -> tuple[BitwardenPasswordlessVerifiedUser | None, str]:
+    r"""Verify the sign in token with the backend to complete the sign in process.
+
+    Parameters
+    ----------
+    client : BitwardenPasswordlessClient
+        The Bitwarden Passwordless client to use for interacting with
+        the Bitwarden Passwordless API.
+
+    token : str
+        The token to verify.
+
+    Returns
+    -------
+    verified_user : streamlit_passwordless.BitwardenPasswordlessVerifiedUser or None
+        Details from Bitwarden Passwordless about the user that was signed in.
+        None is returned if an error occurred during the sign in process. `verified_user` is
+        also stored in the session state with the key `config.SK_BP_VERIFIED_USER`.
+
+    error_msg : str
+        An error message about what failed during the sign in process.
+        An empty string is returned if no errors occurred.
+    """
+
+    error_msg = ''
+    verified_user: BitwardenPasswordlessVerifiedUser | None = None
+
+    try:
+        verified_user = client.verify_sign_in(token=token)
+    except exceptions.SignInTokenVerificationError as e:
+        error_msg = str(e)
+        logger.error(error_msg)
+    except exceptions.StreamlitPasswordlessError as e:
+        error_msg = f'Error creating verified user!\n{str(e)}'
+        logger.error(error_msg)
+
+    st.session_state[config.SK_BP_VERIFIED_USER] = verified_user
+
+    return verified_user, error_msg

--- a/src/streamlit_passwordless/components/ids.py
+++ b/src/streamlit_passwordless/components/ids.py
@@ -4,6 +4,7 @@ r"""The ID:s of components used for identification and session state management.
 # Register form
 # =====================================================================================
 
+BP_REGISTER_FORM = 'bp-register-form'
 BP_REGISTER_FORM_USERNAME_TEXT_INPUT = 'bp-register-form-username-text-input'
 BP_REGISTER_FORM_DISPLAYNAME_TEXT_INPUT = 'bp-register-form-displayname-text-input'
 BP_REGISTER_FORM_ALIASES_TEXT_INPUT = 'bp-register-form-aliases-text-input'

--- a/src/streamlit_passwordless/components/register_form.py
+++ b/src/streamlit_passwordless/components/register_form.py
@@ -85,7 +85,10 @@ def _validate_username(
 
 
 def _create_user(
-    username: str, displayname: str | None = None, aliases: str | None = None
+    username: str,
+    user_id: str | None = None,
+    displayname: str | None = None,
+    aliases: str | None = None,
 ) -> tuple[models.User | None, str]:
     r"""Create a new user to register.
 
@@ -94,10 +97,14 @@ def _create_user(
     username : str
         The username.
 
+    user_id : str or None, default None
+        The unique ID of the user, which serves as the primary key in the database.
+        If None it will be generated as a uuid.
+
     displayname : str or None, default None
         The optional displayname of the user.
 
-    aliases : str | None, default None
+    aliases : str or None, default None
         The optional aliases of the user as a semicolon separated string.
 
     Returns
@@ -112,7 +119,9 @@ def _create_user(
 
     error_msg = ''
     try:
-        user = models.User(username=username, displayname=displayname, aliases=aliases)
+        user = models.User(
+            username=username, user_id=user_id, displayname=displayname, aliases=aliases
+        )
     except exceptions.StreamlitPasswordlessError as e:
         error_msg = str(e)
         logger.error(error_msg)

--- a/src/streamlit_passwordless/components/register_form.py
+++ b/src/streamlit_passwordless/components/register_form.py
@@ -252,22 +252,22 @@ def bitwarden_register_form(
     register_token = ''
     error_msg = ''
     use_default_help = '__default__'
-    help: str | None = None
+    _help: str | None = None
     banner_container = st.empty()
 
     with st.container(border=border):
         st.markdown(title)
 
         if username_help == use_default_help:
-            help = 'A unique identifier for the account. E.g. an email address.'
+            _help = 'A unique identifier for the account. E.g. an email address.'
         else:
-            help = username_help
+            _help = username_help
 
         username = st.text_input(
             label=username_label,
             placeholder=username_placeholder,
             max_chars=username_max_length,
-            help=help,
+            help=_help,
             on_change=_validate_username,
             kwargs={
                 'db_session': db_session,
@@ -280,15 +280,15 @@ def bitwarden_register_form(
 
         if with_displayname:
             if displayname_help == use_default_help:
-                help = 'A descriptive name of the user.'
+                _help = 'A descriptive name of the user.'
             else:
-                help = displayname_help
+                _help = displayname_help
 
             displayname = st.text_input(
                 label=displayname_label,
                 placeholder=displayname_placeholder,
                 max_chars=displayname_max_length,
-                help=help,
+                help=_help,
                 disabled=disabled,
                 key=ids.BP_REGISTER_FORM_DISPLAYNAME_TEXT_INPUT,
             )
@@ -297,19 +297,19 @@ def bitwarden_register_form(
 
         if with_alias:
             if alias_help == use_default_help:
-                help = (
+                _help = (
                     'One or more aliases that can be used to sign in to the account. '
                     'Aliases are separated by semicolon (";"). The username is always '
                     'added as an alias. An alias must be unique across all users.'
                 )
             else:
-                help = alias_help
+                _help = alias_help
 
             aliases = st.text_input(
                 label=alias_label,
                 placeholder=alias_placeholder,
                 max_chars=alias_max_length,
-                help=help,
+                help=_help,
                 disabled=disabled,
                 key=ids.BP_REGISTER_FORM_ALIASES_TEXT_INPUT,
             )

--- a/src/streamlit_passwordless/components/register_form.py
+++ b/src/streamlit_passwordless/components/register_form.py
@@ -14,7 +14,7 @@ from streamlit_passwordless import exceptions, models
 from streamlit_passwordless.bitwarden_passwordless.client import BitwardenPasswordlessClient
 from streamlit_passwordless.bitwarden_passwordless.frontend import register_button
 
-from . import config, ids
+from . import config, core, ids
 
 logger = logging.getLogger(__name__)
 
@@ -449,6 +449,14 @@ def bitwarden_register_form(
         with banner_container:
             st.error(error_msg, icon=config.ICON_ERROR)
         return
+
+    # The user is still registered even though the sign in may fail
+    verified_user, error_msg = core.verify_sign_in(client=client, token=token)
+    if verified_user is None and not verified_user.success:
+        error_msg = f'User {username} was registered, but the sign in attempt with registered passkey failed!'
+    if error_msg:
+        with banner_container:
+            st.error(error_msg, icon=config.ICON_ERROR)
 
     if not db_user:
         user_create = db.UserCreate(

--- a/src/streamlit_passwordless/models.py
+++ b/src/streamlit_passwordless/models.py
@@ -51,6 +51,9 @@ class User(BaseModel):
     displayname: str | None = None
     aliases: tuple[str, ...] | str | None = Field(default=None, validate_default=True)
 
+    def __hash__(self) -> int:
+        return hash(self.user_id)
+
     @field_validator('user_id')
     def generate_user_id(cls, v: str | None) -> str:
         r"""Generate a user ID if not supplied."""


### PR DESCRIPTION
Adding database support to save a new user to the database.

Grouped the username, displayname and alias fields of the form into a Streamlit form.
This allows the user to enter all user form fields before rerunning the application,
which ensures a new user is only created once when all desired fields are filled in.
Before a rerun was triggered whenever a form filed was filled in causing a new user
to be created each time. This caused a mismatch in the user_id registered with
Bitwarden Passwordless and the user_id saved to the database. Now there is one button
for validating the form and one button for registering a new passkey credential with the user.