### PR TITLE
Updating bitwarden_passwordless sub-package

### DIFF
--- a/conda/streamlit_passwordless_dev_linux-64_lock.yml
+++ b/conda/streamlit_passwordless_dev_linux-64_lock.yml
@@ -23,45 +23,46 @@ dependencies:
   - aws-checksums=0.1.13=h5eee18b_0
   - aws-crt-cpp=0.18.16=h6a678d5_0
   - aws-sdk-cpp=1.10.55=h721c034_0
-  - black=24.3.0=py312h06a4308_0
-  - blas=1.0=openblas
+  - black=24.4.2=py312h06a4308_0
+  - blas=1.0=mkl
   - bleach=4.1.0=pyhd3eb1b0_0
   - blinker=1.6.2=py312h06a4308_0
   - boost-cpp=1.82.0=hdb19cb5_2
   - bottleneck=1.3.7=py312ha883a20_0
-  - brotli-python=1.0.9=py312h6a678d5_7
-  - bzip2=1.0.8=h5eee18b_5
+  - brotli-python=1.0.9=py312h6a678d5_8
+  - bzip2=1.0.8=h5eee18b_6
   - c-ares=1.19.1=h5eee18b_0
-  - ca-certificates=2024.3.11=h06a4308_0
-  - cachetools=4.2.2=pyhd3eb1b0_0
-  - certifi=2024.2.2=py312h06a4308_0
-  - cffi=1.16.0=py312h5eee18b_0
-  - charset-normalizer=2.0.4=pyhd3eb1b0_0
+  - ca-certificates=2024.7.4=hbcca054_0
+  - cachetools=5.3.3=py312h06a4308_0
+  - certifi=2024.8.30=py312h06a4308_0
+  - cffi=1.16.0=py312h5eee18b_1
+  - charset-normalizer=3.3.2=pyhd3eb1b0_0
   - click=8.1.7=py312h06a4308_0
   - cmarkgfm=2022.10.27=py312h5eee18b_0
-  - cryptography=42.0.5=py312hdda0065_0
+  - cryptography=43.0.0=py312hdda0065_0
   - dbus=1.13.18=hb2f20db_0
   - docutils=0.18.1=py312h06a4308_3
-  - expat=2.6.2=h6a678d5_0
+  - expat=2.6.3=h6a678d5_0
   - flake8=7.0.0=py312h06a4308_0
   - freetype=2.12.1=h4a9f257_0
   - gflags=2.2.2=h6a678d5_1
   - gitdb=4.0.7=pyhd3eb1b0_0
-  - gitpython=3.1.37=py312h06a4308_0
+  - gitpython=3.1.43=py312h06a4308_0
   - glib=2.78.4=h6a678d5_0
   - glib-tools=2.78.4=h6a678d5_0
   - glog=0.5.0=h6a678d5_1
   - greenlet=3.0.1=py312h6a678d5_0
   - grpc-cpp=1.48.2=he1ff14a_1
   - icu=73.1=h6a678d5_0
-  - idna=3.4=py312h06a4308_0
+  - idna=3.7=py312h06a4308_0
   - importlib-metadata=7.0.1=py312h06a4308_0
   - iniconfig=1.1.1=pyhd3eb1b0_0
-  - isort=5.9.3=pyhd3eb1b0_0
+  - intel-openmp=2023.1.0=hdb19cb5_46306
+  - isort=5.13.2=py312h06a4308_0
   - jaraco.classes=3.2.1=pyhd3eb1b0_0
   - jeepney=0.7.1=pyhd3eb1b0_0
-  - jinja2=3.1.3=py312h06a4308_0
-  - jpeg=9e=h5eee18b_1
+  - jinja2=3.1.4=py312h06a4308_0
+  - jpeg=9e=h5eee18b_3
   - jsonschema=4.19.2=py312h06a4308_0
   - jsonschema-specifications=2023.7.1=py312h06a4308_0
   - keyring=24.3.1=py312h06a4308_0
@@ -70,55 +71,60 @@ dependencies:
   - ld_impl_linux-64=2.38=h1181459_1
   - lerc=3.0=h295c915_0
   - libboost=1.82.0=h109eef0_2
-  - libbrotlicommon=1.0.9=h5eee18b_7
-  - libbrotlidec=1.0.9=h5eee18b_7
-  - libbrotlienc=1.0.9=h5eee18b_7
-  - libcurl=8.5.0=h251f7ec_0
+  - libbrotlicommon=1.0.9=h5eee18b_8
+  - libbrotlidec=1.0.9=h5eee18b_8
+  - libbrotlienc=1.0.9=h5eee18b_8
+  - libcurl=8.9.1=h251f7ec_0
   - libdeflate=1.17=h5eee18b_1
   - libedit=3.1.20230828=h5eee18b_0
   - libev=4.33=h7f8727e_1
   - libevent=2.1.12=hdbd6064_1
-  - libffi=3.4.4=h6a678d5_0
+  - libffi=3.4.4=h6a678d5_1
   - libgcc-ng=11.2.0=h1234567_1
   - libgfortran-ng=11.2.0=h00389a5_1
   - libgfortran5=11.2.0=h1234567_1
   - libglib=2.78.4=hdc74915_0
   - libgomp=11.2.0=h1234567_1
-  - libiconv=1.16=h7f8727e_2
+  - libiconv=1.16=h5eee18b_3
   - libnghttp2=1.57.0=h2d74bed_0
   - libopenblas=0.3.21=h043d6bf_0
   - libpng=1.6.39=h5eee18b_0
   - libprotobuf=3.20.3=he621ea3_0
-  - libssh2=1.10.0=hdbd6064_2
+  - libssh2=1.11.0=h251f7ec_0
   - libstdcxx-ng=11.2.0=h1234567_1
   - libthrift=0.15.0=h1795dd8_2
   - libtiff=4.5.1=h6a678d5_0
   - libuuid=1.41.5=h5eee18b_0
   - libwebp-base=1.3.2=h5eee18b_0
-  - lz4-c=1.9.4=h6a678d5_0
+  - lz4-c=1.9.4=h6a678d5_1
   - markdown-it-py=2.2.0=py312h06a4308_1
   - markupsafe=2.1.3=py312h5eee18b_0
   - marshmallow=3.19.0=py312h06a4308_0
   - mccabe=0.7.0=pyhd3eb1b0_0
   - mdurl=0.1.0=py312h06a4308_0
+  - mkl=2023.1.0=h213fc3f_46344
+  - mkl-service=2.4.0=py312h5eee18b_1
+  - mkl_fft=1.3.10=py312h5eee18b_0
+  - mkl_random=1.2.7=py312h526ad5a_0
   - more-itertools=10.1.0=py312h06a4308_0
-  - mypy=1.8.0=py312h5eee18b_0
+  - mypy=1.10.0=py312h5eee18b_0
   - mypy_extensions=1.0.0=py312h06a4308_0
   - ncurses=6.4=h6a678d5_0
-  - numexpr=2.8.7=py312he7dcb8a_0
-  - numpy=1.26.4=py312h2809609_0
-  - numpy-base=1.26.4=py312he1a6c75_0
-  - openjpeg=2.4.0=h3ad879b_0
-  - openssl=3.0.13=h7f8727e_2
+  - numexpr=2.8.7=py312hf827012_0
+  - numpy=1.26.4=py312hc5e2394_0
+  - numpy-base=1.26.4=py312h0da6c21_0
+  - openjpeg=2.5.2=he7f1fd0_0
+  - openssl=3.0.15=h5eee18b_0
   - orc=1.7.4=hb3bc3d3_1
-  - packaging=23.2=py312h06a4308_0
-  - pandas=2.2.1=py312h526ad5a_0
-  - passwordless=1.0.1=pyhd8ed1ab_0
+  - packaging=24.1=py312h06a4308_0
+  - pandas=2.2.2=py312h526ad5a_0
+  - pandas-stubs=2.1.4.231227=py312h06a4308_0
+  - passwordless=1.0.2=pyhd8ed1ab_0
   - pathspec=0.10.3=py312h06a4308_0
-  - pcre2=10.42=hebb0a14_0
-  - pillow=10.2.0=py312h5eee18b_0
-  - pip=23.3.1=py312h06a4308_0
-  - pkginfo=1.9.6=py312h06a4308_0
+  - pcre2=10.42=hebb0a14_1
+  - pillow=10.4.0=py312h5eee18b_0
+  - pip=24.2=py312h06a4308_0
+  - pkginfo=1.10.0=py312h06a4308_0
   - platformdirs=3.10.0=py312h06a4308_0
   - pluggy=1.0.0=py312h06a4308_1
   - protobuf=3.20.3=py312h6a678d5_0
@@ -126,55 +132,57 @@ dependencies:
   - pyarrow=14.0.2=py312hb107042_0
   - pycodestyle=2.11.1=py312h06a4308_0
   - pycparser=2.21=pyhd3eb1b0_0
-  - pydantic=2.5.3=py312h06a4308_0
-  - pydantic-core=2.14.6=py312hb02cf49_0
+  - pydantic=2.8.2=py312h06a4308_0
+  - pydantic-core=2.20.1=py312hb02cf49_0
   - pydeck=0.8.0=py312h06a4308_2
   - pyflakes=3.2.0=py312h06a4308_0
   - pygments=2.15.1=py312h06a4308_1
   - pyproject_hooks=1.0.0=py312h06a4308_0
   - pysocks=1.7.1=py312h06a4308_0
-  - pytest=7.4.0=py312h06a4308_0
-  - python=3.12.3=h996f2a0_0
+  - pytest=7.4.4=py312h06a4308_0
+  - python=3.12.4=h5148396_1
   - python-build=0.10.0=py312h06a4308_0
-  - python-dateutil=2.8.2=pyhd3eb1b0_0
+  - python-dateutil=2.9.0post0=py312h06a4308_2
   - python-dotenv=0.21.0=py312h06a4308_0
   - python-tzdata=2023.3=pyhd3eb1b0_0
-  - pytz=2023.3.post1=py312h06a4308_0
+  - pytz=2024.1=py312h06a4308_0
   - pyyaml=6.0.1=py312h5eee18b_0
   - re2=2022.04.01=h295c915_0
   - readline=8.2=h5eee18b_0
   - readme_renderer=40.0=py312h06a4308_0
   - referencing=0.30.2=py312h06a4308_0
-  - requests=2.31.0=py312h06a4308_1
+  - requests=2.32.3=py312h06a4308_0
   - requests-toolbelt=1.0.0=py312h06a4308_0
   - rfc3986=1.4.0=pyhd3eb1b0_0
-  - rich=13.3.5=py312h06a4308_1
+  - rich=13.7.1=py312h06a4308_0
   - rpds-py=0.10.6=py312hb02cf49_0
   - s2n=1.3.27=hdbd6064_0
   - secretstorage=3.3.1=py312h06a4308_1
-  - setuptools=68.2.2=py312h06a4308_0
+  - setuptools=72.1.0=py312h06a4308_0
   - six=1.16.0=pyhd3eb1b0_1
   - smmap=4.0.0=pyhd3eb1b0_0
-  - snappy=1.1.10=h6a678d5_1
-  - sqlalchemy=2.0.25=py312h5eee18b_0
-  - sqlite=3.41.2=h5eee18b_0
-  - streamlit=1.32.0=py312h06a4308_0
-  - tenacity=8.2.2=py312h06a4308_1
-  - tk=8.6.12=h1ccaba5_0
+  - snappy=1.2.1=h6a678d5_0
+  - sqlalchemy=2.0.30=py312h5eee18b_0
+  - sqlite=3.45.3=h5eee18b_0
+  - streamlit=1.37.1=py312h06a4308_0
+  - tbb=2021.8.0=hdb19cb5_0
+  - tenacity=8.2.3=py312h06a4308_0
+  - tk=8.6.14=h39e8969_0
   - toml=0.10.2=pyhd3eb1b0_0
   - toolz=0.12.0=py312h06a4308_0
-  - tornado=6.3.3=py312h5eee18b_0
-  - twine=4.0.2=py312h06a4308_0
-  - typing-extensions=4.9.0=py312h06a4308_1
-  - typing_extensions=4.9.0=py312h06a4308_1
+  - tornado=6.4.1=py312h5eee18b_0
+  - twine=5.1.1=pyhd8ed1ab_0
+  - types-pytz=2022.4.0.0=py312h06a4308_1
+  - typing-extensions=4.11.0=py312h06a4308_0
+  - typing_extensions=4.11.0=py312h06a4308_0
   - tzdata=2024a=h04d1e81_0
-  - urllib3=2.1.0=py312h06a4308_1
+  - urllib3=2.2.2=py312h06a4308_0
   - utf8proc=2.6.1=h5eee18b_1
-  - watchdog=2.1.6=py312h06a4308_0
+  - watchdog=4.0.1=py312h06a4308_0
   - webencodings=0.5.1=py312h06a4308_2
-  - wheel=0.41.2=py312h06a4308_0
-  - xz=5.4.6=h5eee18b_0
+  - wheel=0.43.0=py312h06a4308_0
+  - xz=5.4.6=h5eee18b_1
   - yaml=0.2.5=h7b6447c_0
   - zipp=3.17.0=py312h06a4308_0
-  - zlib=1.2.13=h5eee18b_0
-  - zstd=1.5.5=hc292b87_0
+  - zlib=1.2.13=h5eee18b_1
+  - zstd=1.5.5=hc292b87_2

--- a/src/streamlit_passwordless/bitwarden_passwordless/__init__.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/__init__.py
@@ -1,8 +1,8 @@
 r"""The Bitwarden Passwordless package."""
 
 # Local
-from .backend import BitwardenPasswordlessVerifiedUser, BitwardenRegisterConfig
-from .client import BitwardenPasswordlessClient, PasskeyCredential
+from .backend import BitwardenPasswordlessVerifiedUser
+from .client import BitwardenPasswordlessClient, BitwardenRegisterConfig, PasskeyCredential
 from .frontend import register_button, sign_in_button
 
 # The Public API

--- a/src/streamlit_passwordless/bitwarden_passwordless/backend.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/backend.py
@@ -6,13 +6,7 @@ from datetime import datetime, timedelta
 from typing import Literal, Self, TypeAlias
 
 # Third party
-from passwordless import (
-    PasswordlessClient,
-    PasswordlessError,
-    RegisterToken,
-    VerifiedUser,
-    VerifySignIn,
-)
+from passwordless import PasswordlessClient, PasswordlessError, VerifiedUser, VerifySignIn
 from pydantic import AnyHttpUrl
 
 # Local
@@ -155,63 +149,6 @@ class BitwardenPasswordlessVerifiedUser(models.BaseModel):
             type=verified_user.type,
             rp_id=verified_user.rp_id,
         )
-
-
-def _create_register_token(
-    client: BackendClient, user: models.User, register_config: BitwardenRegisterConfig
-) -> str:
-    r"""Create a register token to use for registering a device for a user.
-
-    Parameters
-    ----------
-    client : BackendClient
-        The Bitwarden Passwordless backend client to use for creating the register token.
-
-    user : streamlit_passwordless.models.User
-        The user to register.
-
-    register_config : BitwardenRegisterConfig
-        The configuration for creating the register token.
-
-    Returns
-    -------
-    str
-        The token to use for registering a device for a user.
-
-    Raises
-    ------
-    streamlit_passwordless.exceptions.RegisterUserError
-        If an error occurs while trying to create the register token using the
-        Bitwarden Passwordless backend API.
-    """
-
-    input_register_config = RegisterToken(
-        user_id=user.user_id,
-        username=user.username,
-        display_name=user.displayname,
-        attestation=register_config.attestation,
-        authenticator_type=register_config.authenticator_type,
-        discoverable=register_config.discoverable,
-        user_verification=register_config.user_verification,
-        aliases=user.aliases,
-        alias_hashing=register_config.alias_hashing,
-        expires_at=register_config.expires_at,
-    )
-
-    try:
-        registered_token = client.register_token(register_token=input_register_config)
-    except PasswordlessError as e:
-        error_msg = f'Error creating register token! {str(e)}\nproblem_details: {e.problem_details}'
-        data = {
-            'input_register_config': input_register_config,
-            'problem_details': e.problem_details,
-        }
-        logger.error(error_msg)
-        raise exceptions.RegisterUserError(error_msg, data=data) from None
-    else:
-        logger.info(f'Successfully created register token for user_id={user.user_id}')
-
-    return registered_token.token  # type: ignore
 
 
 def _verify_sign_in_token(client: BackendClient, token: str) -> BitwardenPasswordlessVerifiedUser:

--- a/src/streamlit_passwordless/bitwarden_passwordless/backend.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/backend.py
@@ -2,66 +2,17 @@ r"""The functions and models for interacting with the Bitwarden Passwordless bac
 
 # Standard library
 import logging
-from datetime import datetime, timedelta
-from typing import Literal, Self, TypeAlias
+from datetime import datetime
+from typing import Self
 
 # Third party
-from passwordless import PasswordlessClient, VerifiedUser
+from passwordless import VerifiedUser
 from pydantic import AnyHttpUrl
 
 # Local
-from streamlit_passwordless import common, models
+from streamlit_passwordless import models
 
 logger = logging.getLogger(__name__)
-
-
-class BitwardenRegisterConfig(models.BaseModel):
-    r"""The available passkey configuration when registering a new user.
-
-    See the `Bitwarden Passwordless`_ documentation for more info about the parameters.
-
-    .. _ Bitwarden Passwordless: https://docs.passwordless.dev/guide/api.html#register-token
-
-    Parameters
-    ----------
-    attestation : Literal['none', 'direct', 'indirect'], default 'none'
-        WebAuthn attestation conveyance preference. 'direct' and 'indirect' are exclusive to the
-        Enterprise plan of Bitwarden Passwordless. Trial & Pro plans are limited to 'none'.
-
-    authenticator_type : Literal['any', 'platform', 'cross-platform'], default 'any'
-        WebAuthn authenticator attachment modality. 'platform' refers to platform specific options
-        such as Windows Hello, FaceID or TouchID, while 'cross-platform' means roaming devices such
-        as security keys. 'any' (default) means any authenticator type is allowed.
-
-    discoverable : bool, default True
-        True allows the user to sign in without a username or alias by creating a
-        client-side discoverable credential.
-
-    user_verification : Literal['preferred', 'required', 'discouraged'], default 'preferred'
-        Set the preference for how user verification (e.g. PIN code or biometrics) works when
-        authenticating.
-
-    validity : timedelta, default timedelta(seconds=120)
-        When the registration token expires and becomes invalid defined as an offset
-        from the start of the registration process.
-
-    alias_hashing : bool, default True
-        True means that aliases for a user are hashed before they are stored in the
-        Bitwarden Passwordless database.
-    """
-
-    attestation: Literal['none', 'direct', 'indirect'] = 'none'
-    authenticator_type: Literal['any', 'platform', 'cross-platform'] = 'any'
-    discoverable: bool = True
-    user_verification: Literal['preferred', 'required', 'discouraged'] = 'preferred'
-    validity: timedelta = timedelta(seconds=120)
-    alias_hashing: bool = True
-
-    @property
-    def expires_at(self) -> datetime:
-        r"""The expiry time of the registration token in timezone UTC."""
-
-        return common.get_current_datetime() + self.validity
 
 
 class BitwardenPasswordlessVerifiedUser(models.BaseModel):

--- a/src/streamlit_passwordless/bitwarden_passwordless/backend.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/backend.py
@@ -8,9 +8,7 @@ from typing import Literal, Self, TypeAlias
 # Third party
 from passwordless import (
     PasswordlessClient,
-    PasswordlessClientBuilder,
     PasswordlessError,
-    PasswordlessOptions,
     RegisterToken,
     VerifiedUser,
     VerifySignIn,
@@ -157,32 +155,6 @@ class BitwardenPasswordlessVerifiedUser(models.BaseModel):
             type=verified_user.type,
             rp_id=verified_user.rp_id,
         )
-
-
-def _build_backend_client(private_key: str, url: str) -> BackendClient:
-    r"""Build the Bitwarden Passwordless backend client.
-
-    Parameters
-    ----------
-    private_key : str
-        The private key that the client uses for authenticating with the
-        Bitwarden Passwordless backend API.
-
-    url : str
-        The base url to the backend API.
-
-    Returns
-    -------
-    BackendClient
-        The backend client.
-    """
-
-    try:
-        options = PasswordlessOptions(api_secret=private_key, api_url=url)
-        return PasswordlessClientBuilder(options=options).build()
-    except Exception as e:
-        error_msg = f'Could not build Bitwarden backend client! {type(e).__name__} : {str(e)}'
-        raise exceptions.StreamlitPasswordlessError(error_msg) from None
 
 
 def _create_register_token(

--- a/src/streamlit_passwordless/bitwarden_passwordless/backend.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/backend.py
@@ -6,13 +6,11 @@ from datetime import datetime, timedelta
 from typing import Literal, Self, TypeAlias
 
 # Third party
-from passwordless import PasswordlessClient, PasswordlessError, VerifiedUser, VerifySignIn
+from passwordless import PasswordlessClient, VerifiedUser
 from pydantic import AnyHttpUrl
 
 # Local
-from streamlit_passwordless import common, exceptions, models
-
-BackendClient: TypeAlias = PasswordlessClient
+from streamlit_passwordless import common, models
 
 logger = logging.getLogger(__name__)
 
@@ -149,46 +147,3 @@ class BitwardenPasswordlessVerifiedUser(models.BaseModel):
             type=verified_user.type,
             rp_id=verified_user.rp_id,
         )
-
-
-def _verify_sign_in_token(client: BackendClient, token: str) -> BitwardenPasswordlessVerifiedUser:
-    r"""Verify the sign in token to complete the sign in process.
-
-    The sign in token is generated from the `frontend._sign_in` function.
-
-    Parameters
-    ----------
-    client : BackendClient
-        The Bitwarden Passwordless backend client to communicate
-        with the Bitwarden Passwordless backend.
-
-    token : str
-        The token to verify.
-
-    Returns
-    -------
-    BitwardenPasswordlessVerifiedUser
-        Details from Bitwarden Passwordless about the user that was signed in.
-
-    Raises
-    ------
-    streamlit_passwordless.SignInTokenVerificationError
-        If the `token` cannot be verified successfully.
-
-    streamlit_passwordless.StreamlitPasswordlessError
-        If an instance of `BitwardenPasswordlessVerifiedUser` cannot be successfully created.
-    """
-
-    try:
-        _verified_user = client.sign_in(verify_sign_in=VerifySignIn(token=token))
-    except PasswordlessError as e:
-        error_msg = f'Error verifying the sign in token!\nproblem_details: {e.problem_details}'
-        data = {
-            'token': token,
-            'problem_details': e.problem_details,
-        }
-        raise exceptions.SignInTokenVerificationError(error_msg, data=data) from None
-
-    return BitwardenPasswordlessVerifiedUser._from_passwordless_verified_user(
-        verified_user=_verified_user
-    )

--- a/src/streamlit_passwordless/bitwarden_passwordless/client.py
+++ b/src/streamlit_passwordless/bitwarden_passwordless/client.py
@@ -2,7 +2,8 @@ r"""The client to use to interact with Bitwarden Passwordless."""
 
 # Standard library
 import logging
-from typing import Any, TypeAlias
+from datetime import datetime, timedelta
+from typing import Any, Literal, TypeAlias
 
 # Third party
 from passwordless import (
@@ -17,13 +18,62 @@ from passwordless import (
 from pydantic import AnyHttpUrl, Field, PrivateAttr
 
 # Local
-from streamlit_passwordless import exceptions, models
+from streamlit_passwordless import common, exceptions, models
 
 from . import backend
 
 BackendClient: TypeAlias = PasswordlessClient
 PasskeyCredential: TypeAlias = Credential
 logger = logging.getLogger(__name__)
+
+
+class BitwardenRegisterConfig(models.BaseModel):
+    r"""The available passkey configuration when registering a new user.
+
+    See the `Bitwarden Passwordless`_ documentation for more info about the parameters.
+
+    .. _ Bitwarden Passwordless: https://docs.passwordless.dev/guide/api.html#register-token
+
+    Parameters
+    ----------
+    attestation : Literal['none', 'direct', 'indirect'], default 'none'
+        WebAuthn attestation conveyance preference. 'direct' and 'indirect' are exclusive to the
+        Enterprise plan of Bitwarden Passwordless. Trial & Pro plans are limited to 'none'.
+
+    authenticator_type : Literal['any', 'platform', 'cross-platform'], default 'any'
+        WebAuthn authenticator attachment modality. 'platform' refers to platform specific options
+        such as Windows Hello, FaceID or TouchID, while 'cross-platform' means roaming devices such
+        as security keys. 'any' (default) means any authenticator type is allowed.
+
+    discoverable : bool, default True
+        True allows the user to sign in without a username or alias by creating a
+        client-side discoverable credential.
+
+    user_verification : Literal['preferred', 'required', 'discouraged'], default 'preferred'
+        Set the preference for how user verification (e.g. PIN code or biometrics) works when
+        authenticating.
+
+    validity : timedelta, default timedelta(seconds=120)
+        When the registration token expires and becomes invalid defined as an offset
+        from the start of the registration process.
+
+    alias_hashing : bool, default True
+        True means that aliases for a user are hashed before they are stored in the
+        Bitwarden Passwordless database.
+    """
+
+    attestation: Literal['none', 'direct', 'indirect'] = 'none'
+    authenticator_type: Literal['any', 'platform', 'cross-platform'] = 'any'
+    discoverable: bool = True
+    user_verification: Literal['preferred', 'required', 'discouraged'] = 'preferred'
+    validity: timedelta = timedelta(seconds=120)
+    alias_hashing: bool = True
+
+    @property
+    def expires_at(self) -> datetime:
+        r"""The expiry time of the registration token in timezone UTC."""
+
+        return common.get_current_datetime() + self.validity
 
 
 class BitwardenPasswordlessClient(models.BaseModel):
@@ -48,9 +98,7 @@ class BitwardenPasswordlessClient(models.BaseModel):
     public_key: str
     private_key: str
     url: AnyHttpUrl = AnyHttpUrl('https://v4.passwordless.dev')
-    register_config: backend.BitwardenRegisterConfig = Field(
-        default_factory=backend.BitwardenRegisterConfig
-    )
+    register_config: BitwardenRegisterConfig = Field(default_factory=BitwardenRegisterConfig)
     _backend_client: BackendClient = PrivateAttr()
 
     def model_post_init(self, __context: Any) -> None:

--- a/src/streamlit_passwordless/exceptions.py
+++ b/src/streamlit_passwordless/exceptions.py
@@ -54,7 +54,7 @@ class StreamlitPasswordlessError(Exception):
             self.parent_exception_name = None
             self.parent_full_message = None
 
-        if not getattr(self, 'parent_message'):
+        if getattr(self, 'parent_message', None) is None:
             self.parent_message = None if e is None else self._get_parent_error_message(e=e)
 
         super().__init__(message)
@@ -65,7 +65,7 @@ class StreamlitPasswordlessError(Exception):
 
         try:
             return e.args[0]
-        except KeyError:
+        except IndexError:
             return None
 
     @property
@@ -83,8 +83,9 @@ class StreamlitPasswordlessError(Exception):
         """
 
         return (
-            f'{self.message}\nParent Exception : {self.parent_exception_name}\n'
-            f'{self.parent_full_message}'
+            f'Message : {self.message}\n'
+            f'Parent Exception : {self.parent_exception_name}\n'
+            f'Parent Full Message :{self.parent_full_message}'
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,7 +144,7 @@ def mocked_get_current_datetime(monkeypatch: pytest.MonkeyPatch) -> datetime:
     m = Mock(spec_set=common.get_current_datetime, return_value=now)
 
     monkeypatch.setattr(
-        streamlit_passwordless.bitwarden_passwordless.backend.common, 'get_current_datetime', m
+        streamlit_passwordless.bitwarden_passwordless.client.common, 'get_current_datetime', m
     )
 
     return now

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,15 +2,19 @@ r"""Fixtures for testing streamlit-passwordless."""
 
 # Standard library
 from datetime import datetime
+from typing import Any
 from unittest.mock import Mock
 from zoneinfo import ZoneInfo
 
 # Third party
 import pytest
+from passwordless import VerifiedUser
+from pydantic import AnyHttpUrl
 
 # Local
 import streamlit_passwordless.bitwarden_passwordless.backend
 from streamlit_passwordless import common, models
+from streamlit_passwordless.bitwarden_passwordless.backend import BitwardenPasswordlessVerifiedUser
 
 # =============================================================================================
 # Models
@@ -55,6 +59,70 @@ def user(user_id: str) -> models.User:
         displayname='M Shadows',
         aliases=('Matt', 'Shadows'),
     )
+
+
+@pytest.fixture()
+def passwordless_verified_user() -> tuple[VerifiedUser, dict[str, Any]]:
+    r"""An instance of `passwordless.VerifiedUser`.
+
+    Returns
+    -------
+    verified_user : passwordless.VerifiedUser
+        The verified user instance.
+
+    data : dict[str, Any]
+        The data used to create `verified_user`.
+    """
+
+    data = {
+        'success': True,
+        'user_id': 'user_id',
+        'timestamp': datetime(2024, 4, 27, 18, 23, 52, tzinfo=ZoneInfo('CET')),
+        'origin': 'https://ax7.com',
+        'device': 'My device',
+        'country': 'SE',
+        'nickname': 'nickname',
+        'credential_id': 'credential_id',
+        'expires_at': datetime(2024, 4, 27, 19, 23, 52),
+        'token_id': 'token_id',
+        'type': 'type',
+        'rp_id': 'rp_id',
+    }
+    verified_user = VerifiedUser(**data)
+
+    return verified_user, data
+
+
+@pytest.fixture()
+def bp_verified_user(
+    passwordless_verified_user: tuple[VerifiedUser, dict[str, Any]]
+) -> tuple[BitwardenPasswordlessVerifiedUser, dict[str, Any]]:
+    r"""An instance of `BitwardenPasswordlessVerifiedUser`.
+
+    `BitwardenPasswordlessVerifiedUser` is the `streamlit_passwordless`
+    implementation of `passwordless.VerifiedUser`.
+
+    Returns
+    -------
+    bp_verified_user : bitwarden_passwordless.backend.BitwardenPasswordlessVerifiedUser
+        The verified user instance.
+
+    data : dict[str, Any]
+        The data used to create `bp_verified_user`.
+    """
+
+    _, input_data = passwordless_verified_user
+
+    data = input_data.copy()
+    data['origin'] = AnyHttpUrl(input_data['origin'])  # type: ignore
+    data['sign_in_timestamp'] = input_data['timestamp']
+    del data['timestamp']
+    data['credential_nickname'] = input_data['nickname']
+    del data['nickname']
+
+    bp_verified_user = BitwardenPasswordlessVerifiedUser.model_validate(data)
+
+    return bp_verified_user, data
 
 
 # =============================================================================================

--- a/tests/test_bitwarden_passwordless/test_backend.py
+++ b/tests/test_bitwarden_passwordless/test_backend.py
@@ -14,14 +14,12 @@ from pydantic import AnyHttpUrl
 
 # Local
 from streamlit_passwordless import exceptions, models
-from streamlit_passwordless.bitwarden_passwordless import backend
 from streamlit_passwordless.bitwarden_passwordless.backend import (
     BackendClient,
     BitwardenPasswordlessVerifiedUser,
     BitwardenRegisterConfig,
     PasswordlessError,
     RegisterToken,
-    _build_backend_client,
     _create_register_token,
     _verify_sign_in_token,
 )
@@ -141,60 +139,6 @@ class TestBitwardenRegisterConfig:
         # Verify
         # ===========================================================
         assert config.expires_at == expires_at_exp
-
-        # Clean up - None
-        # ===========================================================
-
-
-class TestBuildBackendClient:
-    r"""Tests for the function `_build_backend_client`."""
-
-    def test_build_backend_client(self) -> None:
-        r"""Test building an instance of the backend client."""
-
-        # Setup
-        # ===========================================================
-        private_key = 'private key'
-        url = 'https://afterlife.ax7.com'
-
-        # Exercise
-        # ===========================================================
-        client = _build_backend_client(private_key=private_key, url=url)
-
-        # Verify
-        # ===========================================================
-        assert client.options.api_url == url, 'api_url is incorrect!'
-        assert client.options.api_secret == private_key, 'api_secret is incorrect!'
-
-        # Clean up - None
-        # ===========================================================
-
-    @pytest.mark.raises
-    def test_raises_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        r"""Test that a raised exception will be re-raised as `StreamlitPasswordlessError`."""
-
-        # Setup
-        # ===========================================================
-        error_msg_text = 'Unexpected!'
-        error_msg_exp = f'Could not build Bitwarden backend client! ValueError : {error_msg_text}'
-        monkeypatch.setattr(
-            backend.PasswordlessClientBuilder,
-            'build',
-            Mock(side_effect=ValueError(error_msg_text)),
-        )
-
-        # Exercise
-        # ===========================================================
-        with pytest.raises(exceptions.StreamlitPasswordlessError) as exc_info:
-            _build_backend_client(private_key='private_key', url='url')
-
-        # Verify
-        # ===========================================================
-        exc_info_text = exc_info.exconly()
-        print(exc_info_text)
-        error_msg = exc_info.value.args[0]
-
-        assert error_msg == error_msg_exp
 
         # Clean up - None
         # ===========================================================

--- a/tests/test_bitwarden_passwordless/test_backend.py
+++ b/tests/test_bitwarden_passwordless/test_backend.py
@@ -3,7 +3,6 @@ r"""Unit tests for the backend module of the bitwarden_passwordless library."""
 # Standard library
 from datetime import datetime, timedelta
 from typing import Any
-from unittest.mock import Mock
 from zoneinfo import ZoneInfo
 
 # Third party
@@ -14,81 +13,9 @@ from pydantic import AnyHttpUrl
 # Local
 from streamlit_passwordless import exceptions
 from streamlit_passwordless.bitwarden_passwordless.backend import (
-    BackendClient,
     BitwardenPasswordlessVerifiedUser,
     BitwardenRegisterConfig,
-    PasswordlessError,
-    _verify_sign_in_token,
 )
-
-# =============================================================================================
-# Fixtures
-# =============================================================================================
-
-
-@pytest.fixture()
-def passwordless_verified_user() -> tuple[VerifiedUser, dict[str, Any]]:
-    r"""An instance of `passwordless.VerifiedUser`.
-
-    Returns
-    -------
-    verified_user : passwordless.VerifiedUser
-        The verified user instance.
-
-    data : dict[str, Any]
-        The data used to create `verified_user`.
-    """
-
-    data = {
-        'success': True,
-        'user_id': 'user_id',
-        'timestamp': datetime(2024, 4, 27, 18, 23, 52, tzinfo=ZoneInfo('CET')),
-        'origin': 'https://ax7.com',
-        'device': 'My device',
-        'country': 'SE',
-        'nickname': 'nickname',
-        'credential_id': 'credential_id',
-        'expires_at': datetime(2024, 4, 27, 19, 23, 52),
-        'token_id': 'token_id',
-        'type': 'type',
-        'rp_id': 'rp_id',
-    }
-    verified_user = VerifiedUser(**data)
-
-    return verified_user, data
-
-
-@pytest.fixture()
-def bp_verified_user(
-    passwordless_verified_user: tuple[VerifiedUser, dict[str, Any]]
-) -> tuple[BitwardenPasswordlessVerifiedUser, dict[str, Any]]:
-    r"""An instance of `BitwardenPasswordlessVerifiedUser`.
-
-    `BitwardenPasswordlessVerifiedUser` is the `streamlit_passwordless`
-    implementation of `passwordless.VerifiedUser`.
-
-    Returns
-    -------
-    bp_verified_user : bitwarden_passwordless.backend.BitwardenPasswordlessVerifiedUser
-        The verified user instance.
-
-    data : dict[str, Any]
-        The data used to create `bp_verified_user`.
-    """
-
-    _, input_data = passwordless_verified_user
-
-    data = input_data.copy()
-    data['origin'] = AnyHttpUrl(input_data['origin'])  # type: ignore
-    data['sign_in_timestamp'] = input_data['timestamp']
-    del data['timestamp']
-    data['credential_nickname'] = input_data['nickname']
-    del data['nickname']
-
-    bp_verified_user = BitwardenPasswordlessVerifiedUser.model_validate(data)
-
-    return bp_verified_user, data
-
 
 # =============================================================================================
 # Tests
@@ -245,74 +172,6 @@ class TestBitwardenPasswordlessVerifiedUser:
         # Verify
         # ===========================================================
         assert bp_verified_user_result.model_dump() == bp_verified_user_exp.model_dump()
-
-        # Clean up - None
-        # ===========================================================
-
-
-class TestVerifySignInToken:
-    r"""Tests for the function `_verify_sign_in_token`."""
-
-    def test_called_correctly(
-        self,
-        passwordless_verified_user: tuple[VerifiedUser, dict[str, Any]],
-        bp_verified_user: tuple[BitwardenPasswordlessVerifiedUser, dict[str, Any]],
-    ) -> None:
-        r"""Test that the `_verify_sign_in_token` function can be called correctly."""
-
-        # Setup
-        # ===========================================================
-        verified_user, _ = passwordless_verified_user
-        bp_verified_user_exp, _ = bp_verified_user
-        token = 'my_token'
-
-        client = Mock(spec_set=BackendClient, name='MockedBackendClient')
-        client.sign_in.return_value = verified_user
-
-        # Exercise
-        # ===========================================================
-        bp_verified_user_result = _verify_sign_in_token(client=client, token=token)
-
-        # Verify
-        # ===========================================================
-        assert bp_verified_user_result.model_dump() == bp_verified_user_exp.model_dump()
-
-        # Clean up - None
-        # ===========================================================
-
-    @pytest.mark.raises
-    def test_raises_sign_in_token_verification_error(self) -> None:
-        r"""Test raising `SignInTokenVerificationError`.
-
-        A raised `PasswordlessError` should be re-raised as a `SignInTokenVerificationError`.
-        """
-
-        # Setup
-        # ===========================================================
-        problem_details = {'error': True}
-        token = 'my_token'
-
-        client = Mock(spec_set=BackendClient, name='MockedBackendClient')
-        client.sign_in.side_effect = PasswordlessError(problem_details=problem_details)
-
-        # Exercise
-        # ===========================================================
-        with pytest.raises(exceptions.SignInTokenVerificationError) as exc_info:
-            _verify_sign_in_token(client=client, token=token)
-
-        # Verify
-        # ===========================================================
-        error_msg = exc_info.exconly()
-        print(error_msg)
-
-        assert 'Error verifying the sign in token!' in error_msg, 'Error message is incorrect!'
-        assert f'{problem_details}' in error_msg, 'Error message problem_details are incorrect!'
-
-        assert (
-            problem_details == exc_info.value.data['problem_details']
-        ), 'problem_details are incorrect!'
-
-        assert token == exc_info.value.data['token'], 'token is incorrect!'
 
         # Clean up - None
         # ===========================================================

--- a/tests/test_bitwarden_passwordless/test_backend.py
+++ b/tests/test_bitwarden_passwordless/test_backend.py
@@ -1,7 +1,7 @@
 r"""Unit tests for the backend module of the bitwarden_passwordless library."""
 
 # Standard library
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -12,60 +12,11 @@ from pydantic import AnyHttpUrl
 
 # Local
 from streamlit_passwordless import exceptions
-from streamlit_passwordless.bitwarden_passwordless.backend import (
-    BitwardenPasswordlessVerifiedUser,
-    BitwardenRegisterConfig,
-)
+from streamlit_passwordless.bitwarden_passwordless.backend import BitwardenPasswordlessVerifiedUser
 
 # =============================================================================================
 # Tests
 # =============================================================================================
-
-
-class TestBitwardenRegisterConfig:
-    r"""Tests for the `BitwardenRegisterConfig` model."""
-
-    def test_expires_at_property_with_default_value_for_validity(
-        self, mocked_get_current_datetime: datetime
-    ) -> None:
-        r"""Test the `expires_at` property with the default value for `validity`."""
-
-        # Setup
-        # ===========================================================
-        validity = timedelta(seconds=120)
-        expires_at_exp = mocked_get_current_datetime + validity
-
-        # Exercise
-        # ===========================================================
-        config = BitwardenRegisterConfig()
-
-        # Verify
-        # ===========================================================
-        assert config.expires_at == expires_at_exp
-
-        # Clean up - None
-        # ===========================================================
-
-    def test_expires_at_property_with_custom_value_for_validity(
-        self, mocked_get_current_datetime: datetime
-    ) -> None:
-        r"""Test the `expires_at` property with a custom value for `validity`."""
-
-        # Setup
-        # ===========================================================
-        validity = timedelta(hours=1)
-        expires_at_exp = mocked_get_current_datetime + validity
-
-        # Exercise
-        # ===========================================================
-        config = BitwardenRegisterConfig(validity=validity)
-
-        # Verify
-        # ===========================================================
-        assert config.expires_at == expires_at_exp
-
-        # Clean up - None
-        # ===========================================================
 
 
 class TestBitwardenPasswordlessVerifiedUser:

--- a/tests/test_bitwarden_passwordless/test_client.py
+++ b/tests/test_bitwarden_passwordless/test_client.py
@@ -26,6 +26,7 @@ from streamlit_passwordless.bitwarden_passwordless import client
 from streamlit_passwordless.bitwarden_passwordless.client import (
     BackendClient,
     BitwardenPasswordlessClient,
+    BitwardenRegisterConfig,
     backend,
 )
 
@@ -108,6 +109,77 @@ def list_of_credentials() -> tuple[list[Credential], str, list[Credential]]:
 # =============================================================================================
 # Tests
 # =============================================================================================
+
+
+class TestBitwardenRegisterConfig:
+    r"""Tests for the `BitwardenRegisterConfig` model."""
+
+    def test__init__(self) -> None:
+        r"""Test to initialize an instance of `BitwardenRegisterConfig`."""
+
+        # Setup
+        # ===========================================================
+        data = {
+            'attestation': 'direct',
+            'authenticator_type': 'platform',
+            'discoverable': False,
+            'user_verification': 'required',
+            'validity': timedelta(seconds=240),
+            'alias_hashing': False,
+        }
+
+        # Exercise
+        # ===========================================================
+        config = BitwardenRegisterConfig.model_validate(data)
+
+        # Verify
+        # ===========================================================
+        assert config.model_dump() == data
+
+        # Clean up - None
+        # ===========================================================
+
+    def test_expires_at_property_with_default_value_for_validity(
+        self, mocked_get_current_datetime: datetime
+    ) -> None:
+        r"""Test the `expires_at` property with the default value for `validity`."""
+
+        # Setup
+        # ===========================================================
+        validity = timedelta(seconds=120)
+        expires_at_exp = mocked_get_current_datetime + validity
+
+        # Exercise
+        # ===========================================================
+        config = BitwardenRegisterConfig()
+
+        # Verify
+        # ===========================================================
+        assert config.expires_at == expires_at_exp
+
+        # Clean up - None
+        # ===========================================================
+
+    def test_expires_at_property_with_custom_value_for_validity(
+        self, mocked_get_current_datetime: datetime
+    ) -> None:
+        r"""Test the `expires_at` property with a custom value for `validity`."""
+
+        # Setup
+        # ===========================================================
+        validity = timedelta(hours=1)
+        expires_at_exp = mocked_get_current_datetime + validity
+
+        # Exercise
+        # ===========================================================
+        config = BitwardenRegisterConfig(validity=validity)
+
+        # Verify
+        # ===========================================================
+        assert config.expires_at == expires_at_exp
+
+        # Clean up - None
+        # ===========================================================
 
 
 class TestBitwardenPasswordlessClient:


### PR DESCRIPTION
Migrating functionality from the `backend` module to the `client` module of `bitwarden_passwordless` sub-package.
Now that the `client` module only handles backend operations and no frontend operations the `backend` module can be removed in the future.