### PR TITLE
Adding bitwarden register form for an existing user

### DIFF
--- a/src/streamlit_passwordless/__init__.py
+++ b/src/streamlit_passwordless/__init__.py
@@ -22,6 +22,7 @@ from streamlit_passwordless.components import (
     ICON_SUCCESS,
     ICON_WARNING,
     bitwarden_register_form,
+    bitwarden_register_form_existing_user,
     bitwarden_sign_in_form,
     init_session_state,
 )
@@ -67,6 +68,7 @@ __all__ = [
     'ICON_SUCCESS',
     'ICON_WARNING',
     'bitwarden_register_form',
+    'bitwarden_register_form_existing_user',
     'bitwarden_sign_in_form',
     'init_session_state',
     # database

--- a/src/streamlit_passwordless/components/__init__.py
+++ b/src/streamlit_passwordless/components/__init__.py
@@ -2,7 +2,7 @@ r"""The components' library contains the web components of streamlit_passwordles
 
 # Local
 from .config import ICON_ERROR, ICON_SUCCESS, ICON_WARNING, init_session_state
-from .register_form import bitwarden_register_form
+from .register_form import bitwarden_register_form, bitwarden_register_form_existing_user
 from .sign_in_form import bitwarden_sign_in_form
 
 # The Public API
@@ -13,5 +13,6 @@ __all__ = [
     'ICON_WARNING',
     'init_session_state',
     'bitwarden_register_form',
+    'bitwarden_register_form_existing_user',
     'bitwarden_sign_in_form',
 ]

--- a/src/streamlit_passwordless/components/ids.py
+++ b/src/streamlit_passwordless/components/ids.py
@@ -12,6 +12,16 @@ BP_REGISTER_FORM_DISCOVERABILITY_RADIO_BUTTON = 'bp-register-form-discoverabilit
 BP_REGISTER_FORM_DISCOVERABILITY_TOGGLE_SWITCH = 'bp-register-form-discoverability-toggle-switch'
 BP_REGISTER_FORM_ALIASES_TEXT_INPUT = 'bp-register-form-aliases-text-input'
 BP_REGISTER_FORM_SUBMIT_BUTTON = 'bp-register-form-submit-button'
+BP_REGISTER_FORM_EXISTING_USER_CREDENTIAL_NICKNAME_TEXT_INPUT = (
+    'bp-register-form-existing-user-credential-nickname-text-input'
+)
+BP_REGISTER_FORM_EXISTING_USER_DISCOVERABILITY_RADIO_BUTTON = (
+    'bp-register-form-existing-user-discoverability-radio-button'
+)
+BP_REGISTER_FORM_EXISTING_USER_DISCOVERABILITY_TOGGLE_SWITCH = (
+    'bp-register-form-existing-user-discoverability-toggle-switch'
+)
+BP_REGISTER_FORM_EXISTING_USER_SUBMIT_BUTTON = 'bp-register-form-existing-user-submit-button'
 
 # =====================================================================================
 # Sign in form


### PR DESCRIPTION
Adding func `components.register_form.bitwarden_register_form_existing_user`,
which renders the Bitwarden Passwordless register form for an existing user.

Allows an existing user to register a new passkey credential with the application.
The register button is disabled if the user is not signed in.