### PR TITLE
Adding first draft of role management

### DIFF
--- a/src/streamlit_passwordless/database/models.py
+++ b/src/streamlit_passwordless/database/models.py
@@ -61,6 +61,52 @@ class Base(DeclarativeBase):
         )
 
 
+class Role(Base):
+    r"""The role of a user.
+
+    A :class:`User` is associated with a role to manage its privileges within an application.
+    The available roles are predefined by streamlit-passwordless, but can be extended if needed.
+
+    Parameters
+    ----------
+    role_id : int
+        The primary key of the table.
+
+    name : str
+        The name of the role. Must be unique.
+
+    rank : int
+        The rank of the role. A role with a higher rank has more privileges. Used
+        for comparing roles against one another. Two roles may have the same rank.
+
+    description : str or None, default None
+        A description of the role.
+
+    users : list[User]
+        The users that have the role assigned.
+    """
+
+    __tablename__ = 'stp_role'
+
+    role_id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(unique=True)
+    rank: Mapped[int]
+    description: Mapped[str | None]
+    users: Mapped[list['User']] = relationship(back_populates='role')
+
+    def __repr__(self) -> str:
+        return (
+            f'{self.__class__.__name__}(\n'
+            f'    role_id={self.role_id!r},\n'
+            f'    name={self.name!r},\n'
+            f'    rank={self.rank!r},\n'
+            f'    description={self.description!r},\n'
+            f'{self.modified_at_created_at_as_str}\n)'
+        )
+
+
+Index(f'{Role.__tablename__}_name_ix', Role.name)
+
 
 class User(Base):
     r"""The user table.

--- a/src/streamlit_passwordless/database/models.py
+++ b/src/streamlit_passwordless/database/models.py
@@ -13,6 +13,15 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 SCHEMA: str | None = None
 
 
+def _timestamp_col_to_str(col: datetime | None) -> str | None:
+    r"""Convert an optional datetime column to an iso-formatted string.
+
+    To be used for the `__repr__` methods of the models.
+    """
+
+    return col if col is None else col.isoformat()
+
+
 class Base(DeclarativeBase):
     r"""The base model all database models will inherit from.
 
@@ -38,6 +47,19 @@ class Base(DeclarativeBase):
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(), server_default=func.current_timestamp()
     )
+
+    @property
+    def modified_at_created_at_as_str(self) -> str:
+        r"""Stringify the timestamp columns modified_at and created_at.
+
+        To be used in the `__repr__` methods of the models.
+        """
+
+        return (
+            f'    modified_at={_timestamp_col_to_str(self.modified_at)},\n'
+            f'    created_at={_timestamp_col_to_str(self.created_at)},'
+        )
+
 
 
 class User(Base):

--- a/src/streamlit_passwordless/models.py
+++ b/src/streamlit_passwordless/models.py
@@ -3,6 +3,7 @@ r"""The data models of streamlit-passwordless."""
 # Standard library
 import uuid
 from datetime import datetime
+from enum import StrEnum
 
 # Third party
 from pydantic import AliasChoices
@@ -11,6 +12,36 @@ from pydantic import ConfigDict, Field, ValidationError, field_validator
 
 # Local
 from . import exceptions
+
+
+class UserRoleName(StrEnum):
+    r"""The predefined user role names of streamlit-passwordless.
+
+    These roles are created in the database when the database is initialized.
+    The default role of a new user is :attr:`UserRoleName.USER`.
+
+    Members
+    -------
+    VIEWER
+        A user that can only view data within an application.
+
+    USER
+        The standard user with normal privileges. When a user is created it is
+        assigned this role by default.
+
+    SUPERUSER
+        A user with higher privileges that can perform certain
+        operations that a normal `USER` can not.
+
+    ADMIN
+        An admin has full access to everything. Only admin users may sign in to the admin page
+        and manage the users of the application. An application should have at least one admin.
+    """
+
+    VIEWER = 'Viewer'
+    USER = 'User'
+    SUPERUSER = 'SuperUser'
+    ADMIN = 'Admin'
 
 
 class BaseModel(PydanticBaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,153 @@ from .config import TZ_UTC, ModelData
 
 
 @pytest.fixture(scope='session')
+def viewer_role() -> tuple[models.Role, db_models.Role, ModelData]:
+    r"""The VIEWER role.
+
+    Returns
+    -------
+    model : streamlit_passwordless.models.Role
+        The model of the VIEWER role.
+
+    db_model : streamlit_passwordless.database.models.Role
+        The database model of the VIEWER role.
+
+    data : ModelData
+        The input data that created `model`.
+    """
+
+    data = {
+        'role_id': None,
+        'name': models.UserRoleName.VIEWER,
+        'rank': 1,
+        'description': 'A user that can only view data within an application.',
+    }
+    model = models.Role.model_validate(data)
+    db_model = db_models.Role(**data)
+
+    return model, db_model, data
+
+
+@pytest.fixture(scope='session')
+def user_role() -> tuple[models.Role, db_models.Role, ModelData]:
+    r"""The USER role.
+
+    Returns
+    -------
+    model : streamlit_passwordless.models.Role
+        The model of the USER role.
+
+    db_model : streamlit_passwordless.database.models.Role
+        The database model of the USER role.
+
+    data : ModelData
+        The input data that created `model`.
+    """
+
+    data = {
+        'role_id': None,
+        'name': models.UserRoleName.USER,
+        'rank': 2,
+        'description': 'The standard user with normal privileges. The default role for a new user.',
+    }
+    model = models.Role.model_validate(data)
+    db_model = db_models.Role(**data)
+
+    return model, db_model, data
+
+
+@pytest.fixture(scope='session')
+def superuser_role() -> tuple[models.Role, db_models.Role, ModelData]:
+    r"""The SUPERUSER role.
+
+    Returns
+    -------
+    model : streamlit_passwordless.models.Role
+        The model of the SUPERUSER role.
+
+    db_model : streamlit_passwordless.database.models.Role
+        The database model of the SUPERUSER role.
+
+    data : ModelData
+        The input data that created `model`.
+    """
+
+    data = {
+        'role_id': None,
+        'name': models.UserRoleName.SUPERUSER,
+        'rank': 3,
+        'description': (
+            'A user with higher privileges that can perform certain '
+            'operations that a normal `USER` can not.'
+        ),
+    }
+    model = models.Role.model_validate(data)
+    db_model = db_models.Role(**data)
+
+    return model, db_model, data
+
+
+@pytest.fixture(scope='session')
+def admin_role() -> tuple[models.Role, db_models.Role, ModelData]:
+    r"""The ADMIN role.
+
+    Returns
+    -------
+    model : streamlit_passwordless.models.Role
+        The model of the ADMIN role.
+
+    db_model : streamlit_passwordless.database.models.Role
+        The database model of the ADMIN role.
+
+    data : ModelData
+        The input data that created `model`.
+    """
+
+    data = {
+        'role_id': None,
+        'name': models.UserRoleName.ADMIN,
+        'rank': 4,
+        'description': (
+            'An admin has full access to everything. Only admin users may sign '
+            'in to the admin page and manage the users of the application. '
+            'An application should have at least one admin.'
+        ),
+    }
+    model = models.Role.model_validate(data)
+    db_model = db_models.Role(**data)
+
+    return model, db_model, data
+
+
+@pytest.fixture(scope='session')
+def drummer_custom_role() -> tuple[models.CustomRole, db_models.CustomRole, ModelData]:
+    r"""The role of a user that is a drummer.
+
+    Returns
+    -------
+    model : streamlit_passwordless.models.Role
+        The model of the drummer role.
+
+    db_model : streamlit_passwordless.database.models.Role
+        The database model of the drummer role.
+
+    data : ModelData
+        The input data that created `model`.
+    """
+
+    data = {
+        'role_id': 1,
+        'name': 'Drummer',
+        'rank': 4,
+        'description': 'An epic drummer worthy of playing Beast and the Harlot super drum solo.',
+    }
+    model = models.CustomRole.model_validate(data)
+    db_model = db_models.CustomRole(**data)
+
+    return model, db_model, data
+
+
+@pytest.fixture(scope='session')
 def user_1_user_id() -> str:
     r"""The user ID for test user 1 of the test suite."""
 
@@ -184,7 +331,11 @@ def user_1_sign_in_unsuccessful(
 
 
 @pytest.fixture(scope='session')
-def user_1(user_1_user_id: str) -> tuple[models.User, db_models.User, ModelData]:
+def user_1(
+    user_1_user_id: str,
+    superuser_role: tuple[models.Role, db_models.Role, ModelData],
+    drummer_custom_role: tuple[models.CustomRole, db_models.CustomRole, ModelData],
+) -> tuple[models.User, db_models.User, ModelData]:
     r"""Test user 1 without emails and no passkey sign in.
 
     Returns
@@ -199,6 +350,8 @@ def user_1(user_1_user_id: str) -> tuple[models.User, db_models.User, ModelData]
         The input data that created `model`.
     """
 
+    _, db_superuser_role_model, role_data = superuser_role
+    _, db_drummer_custom_role_model, custom_role_data = drummer_custom_role
     user_id = user_1_user_id
     username = 'rev'
     ad_username = 'the.rev'
@@ -215,6 +368,8 @@ def user_1(user_1_user_id: str) -> tuple[models.User, db_models.User, ModelData]
         'verified_at': verified_at,
         'disabled': disabled,
         'disabled_timestamp': disabled_timestamp,
+        'role': role_data,
+        'custom_roles': {'Drummer': custom_role_data},
         'emails': None,
         'sign_in': None,
         'aliases': None,
@@ -226,9 +381,12 @@ def user_1(user_1_user_id: str) -> tuple[models.User, db_models.User, ModelData]
         username=username,
         ad_username=ad_username,
         displayname=displayname,
+        role_id=db_superuser_role_model.role_id,
         verified_at=verified_at,
         disabled=disabled,
         disabled_timestamp=disabled_timestamp,
+        role=db_superuser_role_model,
+        custom_roles={db_drummer_custom_role_model.name: db_drummer_custom_role_model},
     )
 
     return model, db_model, data

--- a/tests/test_database/__init__.py
+++ b/tests/test_database/__init__.py
@@ -1,0 +1,1 @@
+r"""Unit tests for the database sub-package."""

--- a/tests/test_database/test_models.py
+++ b/tests/test_database/test_models.py
@@ -1,0 +1,163 @@
+r"""Unit tests for the database models."""
+
+# Standard library
+from datetime import datetime
+
+# Third party
+import pytest
+
+# Local
+from streamlit_passwordless.database import models as db_models
+from tests.config import TZ_UTC
+
+# =============================================================================================
+# Fixtures
+# =============================================================================================
+
+
+@pytest.fixture(scope='module')
+def modified_at_column() -> tuple[datetime, str]:
+    r"""The value for the modified_at column and its iso-formatted string.
+
+    Returns
+    -------
+    datetime
+        The datetime value of the modified_at column.
+
+    str
+        The iso-formatted string of the modified_at column.
+    """
+
+    return datetime(2024, 10, 16, 18, 31, 31, tzinfo=TZ_UTC), '2024-10-16T18:31:31+00:00'
+
+
+@pytest.fixture(scope='module')
+def created_at_column() -> tuple[datetime, str]:
+    r"""The value for the created_at column and its iso-formatted string.
+
+    Returns
+    -------
+    datetime
+        The datetime value of the created_at column.
+
+    str
+        The iso-formatted string of the created_at column.
+    """
+
+    return datetime(2024, 10, 15, 19, 54, 51, tzinfo=TZ_UTC), '2024-10-15T19:54:51+00:00'
+
+
+# =============================================================================================
+# Tests
+# =============================================================================================
+
+
+class TestRole:
+    r"""Tests for the model `Role`."""
+
+    def test_init_with_defaults(self) -> None:
+        r"""Test to initialize the model with required parameters only."""
+
+        # Setup
+        # ===========================================================
+        name = 'VIEWER'
+        rank = 1
+
+        # Exercise
+        # ===========================================================
+        viewer = db_models.Role(name=name, rank=rank)
+
+        # Verify
+        # ===========================================================
+        assert viewer.role_id is None, 'role_id is incorrect!'
+        assert viewer.name == name, 'name is incorrect!'  # type: ignore
+        assert viewer.rank == rank, 'rank is incorrect!'
+        assert viewer.description is None, 'description is incorrect!'
+        assert viewer.modified_at is None, 'modified_at is incorrect!'
+        assert viewer.created_at is None, 'created_at is incorrect!'
+
+        # Clean up - None
+        # ===========================================================
+
+    def test_init_with_all_parameters(
+        self, created_at_column: tuple[datetime, str], modified_at_column: tuple[datetime, str]
+    ) -> None:
+        r"""Test to supply values for all parameters."""
+
+        # Setup
+        # ===========================================================
+        role_id = 2
+        name = 'USER'
+        rank = 2
+        description = 'A regular user.'
+        modified_at, _ = modified_at_column
+        created_at, _ = created_at_column
+
+        # Exercise
+        # ===========================================================
+        viewer = db_models.Role(
+            role_id=role_id,
+            name=name,
+            rank=rank,
+            description=description,
+            modified_at=modified_at,
+            created_at=created_at,
+        )
+
+        # Verify
+        # ===========================================================
+        assert viewer.role_id == role_id, 'role_id is incorrect!'
+        assert viewer.name == name, 'name is incorrect!'
+        assert viewer.rank == rank, 'rank is incorrect!'
+        assert viewer.description == description, 'description is incorrect!'
+        assert viewer.modified_at == modified_at, 'modified_at is incorrect!'
+        assert viewer.created_at == created_at, 'created_at is incorrect!'
+
+        # Clean up - None
+        # ===========================================================
+
+    def test__repr__(
+        self, created_at_column: tuple[datetime, str], modified_at_column: tuple[datetime, str]
+    ) -> None:
+        r"""Test the `__repr__` method."""
+
+        # Setup
+        # ===========================================================
+        role_id = 1
+        name = 'ADMIN'
+        rank = 4
+        description = 'An admin user.'
+        modified_at, modified_at_str = modified_at_column
+        created_at, created_at_str = created_at_column
+
+        repr_str_exp = f"""Role(
+    role_id={role_id},
+    name='{name}',
+    rank={rank},
+    description='{description}',
+    modified_at={modified_at_str},
+    created_at={created_at_str},
+)"""
+
+        admin = db_models.Role(
+            role_id=role_id,
+            name=name,
+            rank=rank,
+            description=description,
+            modified_at=modified_at,
+            created_at=created_at,
+        )
+
+        # Exercise
+        # ===========================================================
+        result = repr(admin)
+
+        # Verify
+        # ===========================================================
+        print(f'Result:\n{result}\n')
+        print(f'Expected Result:\n{repr_str_exp}')
+
+        assert result == repr_str_exp
+
+        # Clean up - None
+        # ===========================================================

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,7 @@
 r"""Unit tests for the models' module."""
 
 # Standard library
+from copy import deepcopy
 from datetime import datetime
 from typing import Sequence
 
@@ -17,6 +18,172 @@ from .config import ModelData
 # =============================================================================================
 # Tests
 # =============================================================================================
+
+
+class TestBaseRole:
+    r"""Tests for the model `BaseRole`."""
+
+    def test_init_with_defaults(self) -> None:
+        r"""Test to initialize the model with required parameters only."""
+
+        # Setup
+        # ===========================================================
+        input_data = {'name': 'USER', 'rank': 2}
+
+        data_exp = deepcopy(input_data)
+        data_exp['role_id'] = None
+        data_exp['description'] = None
+
+        # Exercise
+        # ===========================================================
+        role = models.Role.model_validate(input_data)
+
+        # Verify
+        # ===========================================================
+        assert role.model_dump() == data_exp
+
+        # Clean up - None
+        # ===========================================================
+
+    def test_init_with_all_parameters(self) -> None:
+        r"""Test to supply values for all parameters."""
+
+        # Setup
+        # ===========================================================
+        input_data = {'role_id': 1, 'name': 'USER', 'rank': 2, 'description': 'description'}
+
+        # Exercise
+        # ===========================================================
+        role = models.Role.model_validate(input_data)
+
+        # Verify
+        # ===========================================================
+        assert role.model_dump() == input_data
+
+        # Clean up - None
+        # ===========================================================
+
+
+class TestRole:
+    r"""Tests for the model `Role`."""
+
+    def test_from_db_role(self, user_role: tuple[models.Role, db_models.Role, ModelData]) -> None:
+        r"""Test to initialize the model from an instance of `database.models.Role`."""
+
+        # Setup
+        # ===========================================================
+        _, db_role, role_data = user_role
+
+        # Exercise
+        # ===========================================================
+        role = models.Role.model_validate(db_role)
+
+        # Verify
+        # ===========================================================
+        assert role.model_dump() == role_data
+
+        # Clean up - None
+        # ===========================================================
+
+    def test_create_viewer(
+        self, viewer_role: tuple[models.Role, db_models.Role, ModelData]
+    ) -> None:
+        r"""Test to create a VIEWER role."""
+
+        # Setup
+        # ===========================================================
+        _, _, role_data = viewer_role
+
+        # Exercise
+        # ===========================================================
+        role = models.Role.create_viewer()
+
+        # Verify
+        # ===========================================================
+        assert role.model_dump() == role_data
+
+        # Clean up - None
+        # ===========================================================
+
+    def test_create_user(self, user_role: tuple[models.Role, db_models.Role, ModelData]) -> None:
+        r"""Test to create a USER role."""
+
+        # Setup
+        # ===========================================================
+        _, _, role_data = user_role
+
+        # Exercise
+        # ===========================================================
+        role = models.Role.create_user()
+
+        # Verify
+        # ===========================================================
+        assert role.model_dump() == role_data
+
+        # Clean up - None
+        # ===========================================================
+
+    def test_create_superuser(
+        self, superuser_role: tuple[models.Role, db_models.Role, ModelData]
+    ) -> None:
+        r"""Test to create a SUPERUSER role."""
+
+        # Setup
+        # ===========================================================
+        _, _, role_data = superuser_role
+
+        # Exercise
+        # ===========================================================
+        role = models.Role.create_superuser()
+
+        # Verify
+        # ===========================================================
+        assert role.model_dump() == role_data
+
+        # Clean up - None
+        # ===========================================================
+
+    def test_create_admin(self, admin_role: tuple[models.Role, db_models.Role, ModelData]) -> None:
+        r"""Test to create an ADMIN role."""
+
+        # Setup
+        # ===========================================================
+        _, _, role_data = admin_role
+
+        # Exercise
+        # ===========================================================
+        role = models.Role.create_admin()
+
+        # Verify
+        # ===========================================================
+        assert role.model_dump() == role_data
+
+        # Clean up - None
+        # ===========================================================
+
+
+class TestCustomRole:
+    r"""Tests for the model `CustomRole`."""
+
+    def test_from_db_custom_role(
+        self, drummer_custom_role: tuple[models.CustomRole, db_models.CustomRole, ModelData]
+    ) -> None:
+        r"""Test to initialize the model from an instance of `database.models.CustomRole`."""
+
+        # Setup
+        # ===========================================================
+        _, db_custom_role, custom_role_data = drummer_custom_role
+
+        # Exercise
+        # ===========================================================
+        custom_role = models.CustomRole.model_validate(db_custom_role)
+
+        # Verify
+        # ===========================================================
+        assert custom_role.model_dump() == custom_role_data
+
+        # Clean up - None
+        # ===========================================================
 
 
 class TestEmail:
@@ -251,11 +418,18 @@ class TestUserSignIn:
 class TestUser:
     r"""Tests for the model `User`."""
 
-    def test_init_with_defaults(self, mocked_user_id: str) -> None:
-        r"""Test to initialize the model with required parameters only."""
+    def test_init_with_defaults(
+        self, mocked_user_id: str, user_role: tuple[models.Role, db_models.Role, ModelData]
+    ) -> None:
+        r"""Test to initialize the model with required parameters only.
+
+        By default a user is created with the `models.UserNameRole.USER` role.
+        """
 
         # Setup
         # ===========================================================
+        _, _, role_data = user_role
+
         username = 'm.shadows'
         data_exp = {
             'user_id': mocked_user_id,
@@ -265,6 +439,8 @@ class TestUser:
             'verified_at': None,
             'disabled': False,
             'disabled_timestamp': None,
+            'role': role_data,
+            'custom_roles': None,
             'emails': None,
             'sign_in': None,
             'aliases': None,
@@ -303,12 +479,21 @@ class TestUser:
             'verified_at': '2024-09-17T20:48:16',
             'disabled': True,
             'disabled_timestamp': '2024-09-18T21:48:16',
+            'role': {'role_id': 1, 'name': 'role', 'rank': 1, 'description': None},
+            'custom_roles': {
+                'custom_role_1': {
+                    'role_id': 1,
+                    'name': 'custom_role',
+                    'rank': 1,
+                    'description': 'description',
+                },
+            },
             'emails': [email_primary_data, email_secondary_data],
             'sign_in': sign_in_data,
             'aliases': 'Matt;Shadows',
         }
 
-        data_exp = input_data.copy()
+        data_exp = deepcopy(input_data)
         data_exp['verified_at'] = datetime(2024, 9, 17, 20, 48, 16)
         data_exp['disabled_timestamp'] = datetime(2024, 9, 18, 21, 48, 16)
         data_exp['aliases'] = ('Matt', 'Shadows')
@@ -331,7 +516,7 @@ class TestUser:
         # ===========================================================
         _, db_user, user_data = user_1
 
-        data_exp = user_data.copy()
+        data_exp = deepcopy(user_data)
         data_exp['emails'] = []
 
         # Exercise


### PR DESCRIPTION
Adding the role models to be able to set a role for a user and add application specific custom roles.
The default roles defined by streamlit-passwordless are:

- VIEWER
  A user that can only view data within an application.

- USER
   The standard user with normal privileges. When a user is created it is assigned this role by default.

- SUPERUSER
  A user with higher privileges that can perform certain operation that a normal `USER` can not.

- ADMIN
  An admin has full access to everything. Only admin users may sign in to the admin page
  and manage the users of the application. An application should have at least one admin.