### PR TITLE
Adding creation of default roles

### DIFF
--- a/src/streamlit_passwordless/database/crud/role.py
+++ b/src/streamlit_passwordless/database/crud/role.py
@@ -156,3 +156,42 @@ def create_role(session: Session, role: RoleCreate, commit: bool = False) -> Rol
         db_commit(session=session, error_msg=error_msg)
 
     return db_role
+
+
+def create_default_roles(session: Session, commit: bool = False) -> tuple[Role, ...]:
+    r"""Create the default roles in the database.
+
+    Parameters
+    ----------
+    session : Session
+        An active database session.
+
+    commit : bool, default False
+        if True the default roles are committed to the database after being added
+        to the session. If False (the default) they are only added to the session.
+
+    Returns
+    -------
+    roles : tuple[streamlit_passwordless.db.models.Role, ...]
+        The created default roles.
+
+    Raises
+    ------
+    streamlit_passwordless.DatabaseError
+        If an error occurs while saving the roles to the database.
+
+    streamlit_passwordless.DatabaseStatementError
+        If there is an error with the executed SQL statement.
+    """
+
+    roles = (Role.create_viewer(), Role.create_user(), Role.create_superuser(), Role.create_admin())
+    session.add_all(roles)
+
+    if commit:
+        error_msg = (
+            f'Unable to save default roles: {", ".join(r.name for r in roles)} to the database!\n'
+            'Check the logs for more details.'
+        )
+        db_commit(session=session, error_msg=error_msg)
+
+    return roles

--- a/src/streamlit_passwordless/database/models.py
+++ b/src/streamlit_passwordless/database/models.py
@@ -3,7 +3,7 @@ r"""The models that represent tables in the database."""
 # Standard library
 import os
 from datetime import datetime
-from typing import ClassVar, Optional
+from typing import ClassVar, Optional, Self
 
 # Third party
 from sqlalchemy import TIMESTAMP, Column, ForeignKey, Index, MetaData, Table, UniqueConstraint, func
@@ -16,6 +16,7 @@ from sqlalchemy.orm import (
 )
 
 # Local
+from streamlit_passwordless.models import UserRoleName
 
 SCHEMA: str | None = os.getenv('STP_DB_SCHEMA')
 metadata_obj = MetaData(schema=SCHEMA)
@@ -132,6 +133,55 @@ class Role(Base):
     rank: Mapped[int]
     description: Mapped[str | None]
     users: Mapped[list['User']] = relationship(back_populates='role')
+
+    @classmethod
+    def create_viewer(cls) -> Self:
+        r"""Create the VIEWER role."""
+
+        return cls(
+            name=UserRoleName.VIEWER,
+            rank=1,
+            description='A user that can only view data within an application.',
+        )
+
+    @classmethod
+    def create_user(cls) -> Self:
+        r"""Create the USER role, which is the default for a new user."""
+
+        return cls(
+            name=UserRoleName.USER,
+            rank=2,
+            description=(
+                'The standard user with normal privileges. The default role for a new user.'
+            ),
+        )
+
+    @classmethod
+    def create_superuser(cls) -> Self:
+        r"""Create the SUPERUSER role."""
+
+        return cls(
+            name=UserRoleName.SUPERUSER,
+            rank=3,
+            description=(
+                'A user with higher privileges that can perform certain '
+                'operations that a normal `USER` can not.'
+            ),
+        )
+
+    @classmethod
+    def create_admin(cls) -> Self:
+        r"""Create the ADMIN role."""
+
+        return cls(
+            name=UserRoleName.ADMIN,
+            rank=4,
+            description=(
+                'An admin has full access to everything. Only admin users may sign '
+                'in to the admin page and manage the users of the application. '
+                'An application should have at least one admin.'
+            ),
+        )
 
 
 Index(f'{Role.__tablename__}_name_ix', Role.name)

--- a/src/streamlit_passwordless/models.py
+++ b/src/streamlit_passwordless/models.py
@@ -63,6 +63,8 @@ class BaseRole(BaseModel):
     :class:`BaseRole` should be subclassed and not used on its own.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     role_id: int | None = None
     name: str
     rank: int

--- a/tests/test_database/test_crud/test_role.py
+++ b/tests/test_database/test_crud/test_role.py
@@ -1,0 +1,125 @@
+r"""Unit tests for the crud operations on the Role model."""
+
+# Standard library
+from itertools import zip_longest
+from unittest.mock import Mock
+
+# Third party
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session, sessionmaker
+
+# Local
+from streamlit_passwordless import exceptions
+from streamlit_passwordless.database.crud.role import create_default_roles
+from streamlit_passwordless.database.models import Role
+
+# =============================================================================================
+# Tests
+# =============================================================================================
+
+
+class TestCreateDefaultRoles:
+    r"""Tests for the function `create_default_roles`."""
+
+    get_roles_order_by_rank_query = select(Role).order_by(Role.rank)
+    exp_roles = (
+        Role(name='Viewer', rank=1),
+        Role(name='User', rank=2),
+        Role(name='SuperUser', rank=3),
+        Role(name='Admin', rank=4),
+    )
+
+    def test_create_default_roles_with_commit(
+        self, empty_sqlite_in_memory_database: tuple[Session, sessionmaker]
+    ) -> None:
+        r"""Test to create the default roles of streamlit-passwordless.
+
+        The default roles are added to the session and committed to the database.
+        """
+
+        # Setup
+        # ===========================================================
+        session, session_factory = empty_sqlite_in_memory_database
+
+        # Exercise
+        # ===========================================================
+        create_default_roles(session=session, commit=True)
+
+        # Verify
+        # ===========================================================
+        with session_factory() as new_session:
+            roles = new_session.scalars(self.get_roles_order_by_rank_query)
+
+            for exp_role, role in zip_longest(self.exp_roles, roles):
+                assert exp_role.name == role.name, 'name attribute is incorrect!'
+                assert exp_role.rank == role.rank, 'rank attribute is incorrect!'
+
+        # Clean up - None
+        # ===========================================================
+
+    def test_create_default_roles_without_commit(
+        self,
+        empty_sqlite_in_memory_database: tuple[Session, sessionmaker],
+    ) -> None:
+        r"""Test to create the default roles of streamlit-passwordless.
+
+        The default roles are only added to the session and not committed.
+        """
+
+        # Setup
+        # ===========================================================
+        session, session_factory = empty_sqlite_in_memory_database
+
+        # Exercise
+        # ===========================================================
+        roles = create_default_roles(session=session, commit=False)
+
+        # Verify
+        # ===========================================================
+        with session_factory() as new_session:
+            roles_from_db = new_session.scalars(self.get_roles_order_by_rank_query).all()
+
+            assert not roles_from_db, 'Default roles found in the database!'
+
+        for exp, role in zip_longest(self.exp_roles, roles):
+            assert exp.name == role.name, 'name attribute is incorrect!'
+            assert exp.rank == role.rank, 'rank attribute is incorrect!'
+
+        # Clean up - None
+        # ===========================================================
+
+    @pytest.mark.raises
+    def test_commit_raises_database_error(
+        self,
+        empty_sqlite_in_memory_database: tuple[Session, sessionmaker],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        r"""Test the error message when an exception is raised while committing."""
+
+        # Setup
+        # ===========================================================
+        session, _ = empty_sqlite_in_memory_database
+        exp_error_msg = (
+            'Unable to save default roles: Viewer, User, SuperUser, Admin to the database!\n'
+            'Check the logs for more details.'
+        )
+        monkeypatch.setattr(
+            session, 'commit', Mock(side_effect=SQLAlchemyError('A mocked error occurred!'))
+        )
+
+        # Exercise
+        # ===========================================================
+        with pytest.raises(exceptions.DatabaseError) as exc_info:
+            create_default_roles(session=session, commit=True)
+
+        # Verify
+        # ===========================================================
+        error_msg = exc_info.exconly()
+        print(error_msg)
+
+        assert exp_error_msg in error_msg
+
+        # Clean up - None
+        # ===========================================================

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,7 @@ from typing import Sequence
 # Third party
 import pytest
 from passwordless import VerifiedUser
+from pydantic import ValidationError
 
 # Local
 from streamlit_passwordless import exceptions, models
@@ -157,6 +158,21 @@ class TestRole:
         # Verify
         # ===========================================================
         assert role.model_dump() == role_data
+
+        # Clean up - None
+        # ===========================================================
+
+    def test_is_immutable(self) -> None:
+        r"""Test that the model is immutable."""
+
+        # Setup
+        # ===========================================================
+        role = models.Role(name='Immutable', rank=1)
+
+        # Exercise & Verify
+        # ===========================================================
+        with pytest.raises(ValidationError):
+            role.name = 'Mutable'  # type: ignore
 
         # Clean up - None
         # ===========================================================


### PR DESCRIPTION
Adding functionality to create the default roles of streamlit-passwordless in the database.
Updating `models.Role` to be immutable.