### PR TITLE
Adding first draft of the admin app

### DIFF
--- a/src/streamlit_passwordless/app/config.py
+++ b/src/streamlit_passwordless/app/config.py
@@ -1,5 +1,8 @@
 r"""The configuration of the Streamlit Passwordless web app."""
 
+# Standard library
+from enum import StrEnum
+
 # Local
 from streamlit_passwordless.bitwarden_passwordless import (
     BitwardenPasswordlessClient,
@@ -17,6 +20,14 @@ MAINTAINER_INFO = f"""\
 
 APP_HOME_PAGE_URL = 'https://github.com/antonlydell/streamlit-passwordless'
 APP_ISSUES_PAGE_URL = 'https://github.com/antonlydell/streamlit-passwordless/issues'
+
+
+class Pages(StrEnum):
+    r"""The pages of the application."""
+
+    ADMIN = 'pages/admin.py'
+    INIT = 'pages/init.py'
+    SIGN_IN = 'pages/sign_in.py'
 
 
 def setup(

--- a/src/streamlit_passwordless/app/controllers/admin.py
+++ b/src/streamlit_passwordless/app/controllers/admin.py
@@ -1,0 +1,22 @@
+r"""The controller of the admin page."""
+
+# Local
+import streamlit_passwordless.database as db
+from streamlit_passwordless.app.views.admin import title
+from streamlit_passwordless.bitwarden_passwordless import BitwardenPasswordlessClient
+
+
+def controller(client: BitwardenPasswordlessClient, db_session: db.Session) -> None:
+    r"""Render the admin page.
+
+    Parameters
+    ----------
+    client : streamlit_passwordless.BitwardenPasswordlessClient
+        An instance of the Bitwarden Passwordless client to
+        communicate with the backend API.
+
+    db_session : streamlit_passwordless.db.Session
+        An active session to the Streamlit Passwordless database.
+    """
+
+    title()

--- a/src/streamlit_passwordless/app/controllers/sign_in.py
+++ b/src/streamlit_passwordless/app/controllers/sign_in.py
@@ -1,0 +1,30 @@
+r"""The controller of the sign in page."""
+
+# Third party
+import streamlit as st
+
+# Local
+import streamlit_passwordless.database as db
+from streamlit_passwordless.app.views.sign_in import title
+from streamlit_passwordless.bitwarden_passwordless import BitwardenPasswordlessClient
+from streamlit_passwordless.components import bitwarden_sign_in_form
+
+
+def controller(client: BitwardenPasswordlessClient, db_session: db.Session) -> None:
+    r"""Render the sign in page.
+
+    Parameters
+    ----------
+    client : streamlit_passwordless.BitwardenPasswordlessClient
+        An instance of the Bitwarden Passwordless client to
+        communicate with the backend API.
+
+    db_session : streamlit_passwordless.db.Session
+        An active session to the Streamlit Passwordless database.
+    """
+
+    with st.container(border=True):
+        title()
+        bitwarden_sign_in_form(
+            client=client, db_session=db_session, with_alias=False, border=False, title=''
+        )

--- a/src/streamlit_passwordless/app/main.py
+++ b/src/streamlit_passwordless/app/main.py
@@ -1,0 +1,27 @@
+r"""The entry point of the Streamlit Passwordless admin app."""
+
+# Standard library
+from pathlib import Path
+
+# Third party
+import streamlit as st
+
+# Local
+from streamlit_passwordless.app.config import Pages
+
+APP_PATH = Path(__file__)
+
+
+def main() -> None:
+    r"""The page router for the Streamlit Passwordless admin app."""
+
+    pages = [
+        st.Page(page=Pages.ADMIN, title='Admin', default=True),
+        st.Page(page=Pages.SIGN_IN, title='Sign in', url_path='sign_in'),
+    ]
+    page = st.navigation(pages)
+    page.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/streamlit_passwordless/app/pages/admin.py
+++ b/src/streamlit_passwordless/app/pages/admin.py
@@ -1,0 +1,44 @@
+r"""The entry point of the admin page."""
+
+# Third party
+import streamlit as st
+
+# Local
+from streamlit_passwordless.app.config import (
+    APP_HOME_PAGE_URL,
+    APP_ISSUES_PAGE_URL,
+    MAINTAINER_INFO,
+    setup,
+)
+from streamlit_passwordless.app.controllers.admin import controller
+
+ABOUT = f"""\
+The Streamlit Passwordless admin web app.
+
+Manage the users of your application.
+
+{MAINTAINER_INFO}
+"""
+
+
+def admin_page() -> None:
+    r"""Run the admin page of the Streamlit Passwordless admin app."""
+
+    st.set_page_config(
+        page_title='Admin - Streamlit Passwordless',
+        page_icon=':bulb:',
+        layout='wide',
+        menu_items={
+            'About': ABOUT,
+            'Get Help': APP_HOME_PAGE_URL,
+            'Report a bug': APP_ISSUES_PAGE_URL,
+        },
+    )
+    client, session_factory, _ = setup()
+
+    with session_factory() as session:
+        controller(client=client, db_session=session)
+
+
+if __name__ == '__main__' or __name__ == '__page__':
+    admin_page()

--- a/src/streamlit_passwordless/app/pages/sign_in.py
+++ b/src/streamlit_passwordless/app/pages/sign_in.py
@@ -1,0 +1,42 @@
+r"""The entry point of the sign in page."""
+
+# Third party
+import streamlit as st
+
+# Local
+from streamlit_passwordless.app.config import (
+    APP_HOME_PAGE_URL,
+    APP_ISSUES_PAGE_URL,
+    MAINTAINER_INFO,
+    setup,
+)
+from streamlit_passwordless.app.controllers.sign_in import controller
+
+ABOUT = f"""\
+Sign in to the Streamlit Passwordless admin web app.
+
+{MAINTAINER_INFO}
+"""
+
+
+def sign_in_page() -> None:
+    r"""Run the sign in page of the Streamlit Passwordless admin app."""
+
+    st.set_page_config(
+        page_title='Admin Sign in - Streamlit Passwordless',
+        page_icon=':key:',
+        layout='centered',
+        menu_items={
+            'About': ABOUT,
+            'Get Help': APP_HOME_PAGE_URL,
+            'Report a bug': APP_ISSUES_PAGE_URL,
+        },
+    )
+    client, session_factory, _ = setup()
+
+    with session_factory() as session:
+        controller(client=client, db_session=session)
+
+
+if __name__ == '__main__' or __name__ == '__page__':
+    sign_in_page()

--- a/src/streamlit_passwordless/app/views/admin.py
+++ b/src/streamlit_passwordless/app/views/admin.py
@@ -1,0 +1,11 @@
+r"""The views of the admin page."""
+
+# Third party
+import streamlit as st
+
+
+def title() -> None:
+    r"""Render the title view of the admin page."""
+
+    st.title('Streamlit Passwordless Admin Console')
+    st.divider()

--- a/src/streamlit_passwordless/app/views/sign_in.py
+++ b/src/streamlit_passwordless/app/views/sign_in.py
@@ -1,0 +1,11 @@
+r"""The views of the sign in page."""
+
+# Third party
+import streamlit as st
+
+
+def title() -> None:
+    r"""Render the title view of the sign in page."""
+
+    st.title('Admin Console')
+    st.subheader('Streamlit Passwordless')

--- a/src/streamlit_passwordless/cli/commands/run.py
+++ b/src/streamlit_passwordless/cli/commands/run.py
@@ -12,6 +12,7 @@ from typing import Iterable
 import click
 
 # Local
+from streamlit_passwordless.app.main import APP_PATH
 from streamlit_passwordless.app.pages.init import INIT_PATH
 
 streamlit_args_argument = click.argument('streamlit_args', nargs=-1, type=click.UNPROCESSED)
@@ -72,3 +73,11 @@ def init(streamlit_args: tuple[str, ...]) -> None:
     """Initialize the Streamlit Passwordless user database."""
 
     run_streamlit_app(path=INIT_PATH, streamlit_args=streamlit_args)
+
+
+@run.command(context_settings={'ignore_unknown_options': True})
+@streamlit_args_argument
+def admin(streamlit_args: tuple[str, ...]) -> None:
+    """Run the Streamlit Passwordless admin web app."""
+
+    run_streamlit_app(path=APP_PATH, streamlit_args=streamlit_args)


### PR DESCRIPTION
The command `stp run admin` launches the admin web app to mange the user database of Streamlit Passwordless.
The app only has a skeleton of the admin page and the sign in page.