### PR TITLE
Updating register forms

### DIFF
--- a/src/streamlit_passwordless/components/config.py
+++ b/src/streamlit_passwordless/components/config.py
@@ -6,7 +6,7 @@ r"""Contains the Streamlit configuration of the web components."""
 import streamlit as st
 
 # Local
-
+from streamlit_passwordless.models import User
 
 # =====================================================================================
 # Session state keys
@@ -90,3 +90,15 @@ def init_session_state() -> None:
     empty_dict_keys = (SK_CREATE_USER_FORM_VALIDATION_ERRORS, SK_ROLES, SK_CUSTOM_ROLES)
     for key in empty_dict_keys:
         st.session_state[key] = {}
+
+
+def get_current_user() -> User | None:
+    r"""Get the current user from the session state.
+
+    Returns
+    -------
+    streamlit_passwordless.User or None
+        The user from the session state. None is returned if a user has not signed in yet.
+    """
+
+    return st.session_state.get(SK_USER)

--- a/src/streamlit_passwordless/components/config.py
+++ b/src/streamlit_passwordless/components/config.py
@@ -16,6 +16,7 @@ SK_USER = 'stp-user'
 SK_USER_SIGN_IN = 'stp-user-sign-in'
 SK_DB_USER = 'stp-db-user'
 SK_REGISTER_FORM_IS_VALID = 'stp-register-form-is-valid'
+SK_REGISTER_FORM_VALIDATION_ERRORS = 'stp-register-form-validation-errors'
 SK_ROLES = 'stp-roles'
 SK_CUSTOM_ROLES = 'stp-custom-roles'
 SK_SESSION_STATE_INITIALIZED = 'stp-session-state-initialized'
@@ -61,6 +62,10 @@ def init_session_state() -> None:
     SK_REGISTER_FORM_IS_VALID : bool, default False
         True if the input to the register form is valid and False otherwise.
 
+    SK_REGISTER_FORM_VALIDATION_ERRORS : dict[str, str]
+        A dictionary mapping of the form field name to its error message
+        for the register form.
+
     SK_ROLES : dict[str, streamlit_passwordless.Role]
         The available roles for a user.
 
@@ -71,7 +76,8 @@ def init_session_state() -> None:
         True if the input to the create user form is valid and False otherwise.
 
     SK_CREATE_USER_FORM_VALIDATION_ERRORS : dict[str, str]
-        A dictionary mapping of the user form field name to its error message.
+        A dictionary mapping of the form field name to its error message
+        for the create user form.
     """
 
     if st.session_state.get(SK_SESSION_STATE_INITIALIZED, False):
@@ -87,7 +93,12 @@ def init_session_state() -> None:
     for key in false_keys:
         st.session_state[key] = False
 
-    empty_dict_keys = (SK_CREATE_USER_FORM_VALIDATION_ERRORS, SK_ROLES, SK_CUSTOM_ROLES)
+    empty_dict_keys = (
+        SK_REGISTER_FORM_VALIDATION_ERRORS,
+        SK_CREATE_USER_FORM_VALIDATION_ERRORS,
+        SK_ROLES,
+        SK_CUSTOM_ROLES,
+    )
     for key in empty_dict_keys:
         st.session_state[key] = {}
 


### PR DESCRIPTION
Improving form validation of `bitwarden_register_form` and adding the `banner_container` parameter to `bitwarden_register_form` and `bitwarden_register_form_existing_user`.
    
banner_container : streamlit_passwordless.BannerContainer or None, default None
         A container produced by :func:`streamlit.empty`, in which error
         or success messages about the register user process will be displayed.
         Useful to make the banner appear at the desired location on a page.
         If None the banner will be displayed right above the form.

Adding func `components.config.get_current_user`, which is a convenience function to get the current user from the session state.
