### PR TITLE
Updating create_user_form

### DIFF
--- a/src/streamlit_passwordless/components/core.py
+++ b/src/streamlit_passwordless/components/core.py
@@ -240,6 +240,44 @@ def create_user_in_database(
     return success, error_msg
 
 
+def get_email_from_database(
+    session: db.Session, email: str, load_user: bool = False
+) -> tuple[db.models.Email | None, str]:
+    r"""Get an email from the database.
+
+    Parameters
+    ----------
+    db_session : streamlit_passwordless.db.Session
+        An active database session.
+
+    email : str
+        The email address to retrieve from the database.
+
+    load_user : bool, default False
+        If True the user that that the email belongs to will also be loaded from the database.
+
+    Returns
+    -------
+    db_email : streamlit_passwordless.db.models.Email or None
+        The email address matching `email` or None if an email was not found.
+
+    error_msg : str
+        An error message to display to the user if there was an issue with retrieving
+        the email from the database. If no error occurred an empty string is returned.
+    """
+
+    try:
+        db_email = db.get_email(session=session, email=email, load_user=load_user)
+    except exceptions.DatabaseError as e:
+        logger.error(e.detailed_message)
+        error_msg = e.displayable_message
+        db_email = None
+    else:
+        error_msg = ''
+
+    return db_email, error_msg
+
+
 def display_banner_message(
     message: str,
     message_type: BannerMessageType = BannerMessageType.SUCCESS,

--- a/src/streamlit_passwordless/database/__init__.py
+++ b/src/streamlit_passwordless/database/__init__.py
@@ -5,6 +5,7 @@ from . import models
 from .cache import create_session_factory, init
 from .core import URL, Session, SessionFactory, commit, create_db_url
 from .crud.custom_role import create_custom_role, get_all_custom_roles, get_custom_roles
+from .crud.email import get_email
 from .crud.role import (
     create_default_roles,
     create_role,
@@ -34,6 +35,8 @@ __all__ = [
     'create_custom_role',
     'get_all_custom_roles',
     'get_custom_roles',
+    # email
+    'get_email',
     # role
     'create_default_roles',
     'create_role',

--- a/src/streamlit_passwordless/database/__init__.py
+++ b/src/streamlit_passwordless/database/__init__.py
@@ -4,6 +4,7 @@ r"""The database functionality of streamlit-passwordless."""
 from . import models
 from .cache import create_session_factory, init
 from .core import URL, Session, SessionFactory, commit, create_db_url
+from .crud.custom_role import create_custom_role, get_all_custom_roles, get_custom_roles
 from .crud.role import (
     create_default_roles,
     create_role,
@@ -29,6 +30,10 @@ __all__ = [
     'SessionFactory',
     'commit',
     'create_db_url',
+    # custom_role
+    'create_custom_role',
+    'get_all_custom_roles',
+    'get_custom_roles',
     # role
     'create_default_roles',
     'create_role',

--- a/src/streamlit_passwordless/database/crud/email.py
+++ b/src/streamlit_passwordless/database/crud/email.py
@@ -1,0 +1,50 @@
+r"""Database operations on the email table stp_email."""
+
+# Standard library
+
+# Third party
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import selectinload
+
+# Local
+from streamlit_passwordless import exceptions
+from streamlit_passwordless.database.core import Session
+from streamlit_passwordless.database.models import Email
+
+
+def get_email(session: Session, email: str, load_user: bool = False) -> Email | None:
+    r"""Get an email from the database.
+
+    Parameters
+    ----------
+    session : Session
+        An active database session.
+
+    email : str
+        The email address to retrieve from the database.
+
+    load_user : bool, default False
+        If True the user that that the email belongs to will also be loaded from the database.
+
+    Returns
+    -------
+    streamlit_passwordless.db.models.Email or None
+        The email address matching `email` or None if an email was not found.
+
+    Raises
+    ------
+    streamlit_passwordless.DatabaseError
+        If an error occurs while loading the email address from the database.
+    """
+
+    query = select(Email).where(Email.email == email)
+    if load_user:
+        query = query.options(selectinload(Email.user))
+
+    try:
+        return session.scalars(query).one_or_none()
+    except SQLAlchemyError as e:
+        raise exceptions.DatabaseError(
+            f'Error loading email "{email}" from database!', e=e
+        ) from None

--- a/tests/test_database/test_crud/test_email.py
+++ b/tests/test_database/test_crud/test_email.py
@@ -1,0 +1,217 @@
+r"""Unit tests for the crud operations on the email table stp_email."""
+
+# Standard library
+from datetime import datetime
+from unittest.mock import Mock
+
+# Third party
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm.exc import DetachedInstanceError
+
+# Local
+from streamlit_passwordless import exceptions
+from streamlit_passwordless.database.crud.email import get_email
+from streamlit_passwordless.database.models import Email, User
+from tests.config import DbWithRoles
+
+# =============================================================================================
+# Fixtures
+# =============================================================================================
+
+
+@pytest.fixture
+def sqlite_in_memory_database_with_user_and_email(
+    sqlite_in_memory_database_with_roles: DbWithRoles,
+) -> tuple[Session, sessionmaker, User]:
+    r"""A SQLite database containing a user with an email."""
+
+    session, session_factory, roles = sqlite_in_memory_database_with_roles
+    role = roles[0]
+
+    exp_email = Email(
+        email='test@example.com',
+        rank=1,
+        verified_at=datetime(2025, 1, 20, 9, 8, 7),
+        disabled=1,
+        disabled_timestamp=datetime(2025, 2, 22, 13, 37, 37),
+        modified_at=datetime(2025, 2, 18, 13, 37, 38),
+        created_at=datetime(2025, 1, 1, 0, 0, 0),
+    )
+    user = User(
+        user_id='user_id',
+        username='username',
+        role_id=role.role_id,
+        emails=[exp_email],
+        modified_at=datetime(2024, 7, 17, 13, 37, 37),
+        created_at=datetime(2024, 6, 6, 13, 37, 38),
+    )
+
+    session.add(user)
+    session.add(exp_email)
+    session.commit()
+
+    return session, session_factory, user
+
+
+# =============================================================================================
+# Tests
+# =============================================================================================
+
+
+class TestGetEmail:
+    r"""Tests for the function `get_email`."""
+
+    def test_get_existing_email(
+        self, sqlite_in_memory_database_with_user_and_email: tuple[Session, sessionmaker, User]
+    ) -> None:
+        r"""Test to get an existing email from the database.
+
+        The user of the email should not be loaded by default.
+        """
+
+        # Setup
+        # ===========================================================
+        session, session_factory, exp_user = sqlite_in_memory_database_with_user_and_email
+        exp_email = exp_user.emails[0]
+
+        # Exercise
+        # ===========================================================
+        with session_factory() as session:
+            email = get_email(session=session, email=exp_email.email)
+
+        # Verify
+        # ===========================================================
+        assert email is not None, 'Expected email was not found!'
+
+        attributes_to_verify = (
+            ('email_id', 1),
+            ('user_id', exp_user.user_id),
+            ('email', exp_email.email),
+            ('rank', exp_email.rank),
+            ('verified_at', exp_email.verified_at),
+            ('disabled', exp_email.disabled),
+            ('disabled_timestamp', exp_email.disabled_timestamp),
+            ('modified_at', exp_email.modified_at),
+            ('created_at', exp_email.created_at),
+        )
+        for attr, exp_value in attributes_to_verify:
+            assert getattr(email, attr) == exp_value, f'{email.email} : email.{attr} is incorrect!'
+
+        with pytest.raises(DetachedInstanceError):  # Check that the user is not loaded.
+            email.user
+
+        # Clean up - None
+        # ===========================================================
+
+    def test_get_non_existing_email(
+        self, sqlite_in_memory_database_with_roles: DbWithRoles
+    ) -> None:
+        r"""Test to get a non-existing email from the database."""
+
+        # Setup
+        # ===========================================================
+        _, session_factory, _ = sqlite_in_memory_database_with_roles
+
+        # Exercise
+        # ===========================================================
+        with session_factory() as session:
+            email = get_email(session=session, email='does not exist')
+
+        # Verify
+        # ===========================================================
+        assert email is None, 'Unexpected email was found!'
+
+        # Clean up - None
+        # ===========================================================
+
+    def test_get_existing_email_load_user_of_email(
+        self, sqlite_in_memory_database_with_user_and_email: tuple[Session, sessionmaker, User]
+    ) -> None:
+        r"""Test to get an existing email from the database.
+
+        The user associated with the email should also be loaded.
+        """
+
+        # Setup
+        # ===========================================================
+        session, session_factory, exp_user = sqlite_in_memory_database_with_user_and_email
+        exp_email = exp_user.emails[0]
+
+        # Exercise
+        # ===========================================================
+        with session_factory() as session:
+            email = get_email(session=session, email=exp_email.email, load_user=True)
+
+        # Verify
+        # ===========================================================
+        assert email is not None, 'Expected email was not found!'
+        assert email.user is not None, 'Expected user was not found!'
+
+        email_attributes_to_verify = (
+            ('email_id', 1),
+            ('user_id', exp_user.user_id),
+            ('email', exp_email.email),
+            ('rank', exp_email.rank),
+            ('verified_at', exp_email.verified_at),
+            ('disabled', exp_email.disabled),
+            ('disabled_timestamp', exp_email.disabled_timestamp),
+            ('modified_at', exp_email.modified_at),
+            ('created_at', exp_email.created_at),
+        )
+        for attr, exp_value in email_attributes_to_verify:
+            assert getattr(email, attr) == exp_value, f'{email.email} : email.{attr} is incorrect!'
+
+        user = email.user
+        user_attributes_to_verify = (
+            ('user_id', exp_user.user_id),
+            ('username', exp_user.username),
+            ('ad_username', exp_user.ad_username),
+            ('displayname', exp_user.displayname),
+            ('role_id', exp_user.role_id),
+            ('verified_at', exp_user.verified_at),
+            ('disabled', exp_user.disabled),
+            ('disabled_timestamp', exp_user.disabled_timestamp),
+            ('modified_at', exp_user.modified_at),
+            ('created_at', exp_user.created_at),
+        )
+        for attr, exp_value in user_attributes_to_verify:
+            assert getattr(user, attr) == exp_value, f'user.{attr} is incorrect!'
+
+        # Clean up - None
+        # ===========================================================
+
+    @pytest.mark.raises
+    def test_database_error(
+        self,
+        empty_sqlite_in_memory_database: tuple[Session, sessionmaker],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        r"""Test the error message when a `streamlit_passwordless.DatabaseError` is raised."""
+
+        # Setup
+        # ===========================================================
+        session, _ = empty_sqlite_in_memory_database
+
+        email = 'test@example.com'
+        exp_error_msg = f'Error loading email "{email}" from database!'
+
+        monkeypatch.setattr(
+            session, 'scalars', Mock(side_effect=SQLAlchemyError('A mocked error occurred!'))
+        )
+
+        # Exercise
+        # ===========================================================
+        with pytest.raises(exceptions.DatabaseError) as exc_info:
+            get_email(session=session, email=email)
+
+        # Verify
+        # ===========================================================
+        error_msg = exc_info.exconly()
+        print(error_msg)
+
+        assert exp_error_msg in error_msg
+
+        # Clean up - None
+        # ===========================================================


### PR DESCRIPTION
Implementing saving custom roles to the database.

The entered email address is now validated and can be saved to the database when the user is created. The email address is always converted to lowercase before saving to the database. Added removing leading and trailing whitespace of data from text input fields before creating the user.

Adding func `streamlit_passwordless.db.get_email`, which gets an email from the database.
