### PR TITLE
Updating admin page

### DIFF
--- a/src/streamlit_passwordless/app/components/__init__.py
+++ b/src/streamlit_passwordless/app/components/__init__.py
@@ -1,0 +1,1 @@
+r"""The components of the web apps."""

--- a/src/streamlit_passwordless/app/components/admin.py
+++ b/src/streamlit_passwordless/app/components/admin.py
@@ -1,0 +1,275 @@
+r"""The components of the admin app."""
+
+# Standard library
+from time import sleep
+from typing import Sequence
+
+# Third party
+import pandas as pd
+import streamlit as st
+
+# Local
+import streamlit_passwordless.database as db
+from streamlit_passwordless.app.components import keys
+from streamlit_passwordless.app.logic.admin import get_selectable_users_from_database
+from streamlit_passwordless.bitwarden_passwordless import BitwardenPasswordlessClient
+from streamlit_passwordless.components import create_user_form
+
+
+@st.dialog(title='Create User')
+def create_user_dialog_form(
+    db_session: db.Session, on_success_exit_after_n_seconds: int | None = 2
+) -> None:
+    r"""Render the form for creating a new user in a dialog frame.
+
+    Parameters
+    ----------
+    db_session : streamlit_passwordless.db.Session
+        An active session to the Streamlit Passwordless database.
+
+    on_success_exit_after_n_seconds : int, default 2
+        The dialog form will close automatically after n number of seconds after a successful
+        user creation. If None the dialog form will not close automatically.
+    """
+
+    created_user = create_user_form(
+        db_session=db_session, with_ad_username=True, border=False, title=''
+    )
+    if created_user is not None:
+        get_selectable_users_from_database(db_session=db_session)
+
+        if on_success_exit_after_n_seconds is not None:
+            sleep(on_success_exit_after_n_seconds)
+
+        st.rerun(scope='app')
+
+
+def user_state_radio_button(
+    label: str = 'User State', key: str = keys.ADMIN_USER_STATE_RADIO_BUTTON
+) -> bool:
+    r"""Render the user state radio button.
+
+    A user can be either enabled or disabled.
+
+    Parameters
+    ----------
+    label : str, default 'User State'
+        The label of the radio button.
+
+    key : str, default streamlit_passwordless.app.keys.ADMIN_USER_STATE_RADIO_BUTTON
+        The unique identifier of the component. Each component on a page must have a unique key.
+    """
+
+    return st.radio(
+        label=label,
+        options=(False, True),
+        format_func=lambda x: 'Enabled' if x is False else 'Disabled',
+        horizontal=True,
+        key=key,
+    )
+
+
+def create_user_button(
+    db_session: db.Session,
+    label: str = 'Create User',
+    disabled: bool = False,
+    key=keys.ADMIN_CREATE_USER_BUTTON,
+) -> bool:
+    r"""Render the button for creating an new user.
+
+    Parameters
+    ----------
+    db_session : streamlit_passwordless.db.Session
+        An active session to the Streamlit Passwordless database.
+
+    label : str, default 'Create User'
+        The label of the button.
+
+    disabled : bool, default False
+        If True the component is disabled from user interaction.
+
+    key : str, default streamlit_passwordless.app.keys.ADMIN_CREATE_USER_BUTTON
+        The unique identifier of the component. Each component on a page must have a unique key.
+
+    Returns
+    -------
+    bool
+        True if the button was clicked and False otherwise.
+    """
+
+    return st.button(
+        label=label,
+        key=key,
+        disabled=disabled,
+        help='Create a new user in the database.',
+        on_click=create_user_dialog_form,
+        kwargs={'db_session': db_session},
+    )
+
+
+def refresh_users_button(
+    db_session: db.Session,
+    label: str = 'Refresh Users',
+    disabled: bool = False,
+    key=keys.ADMIN_REFRESH_USERS_BUTTON,
+) -> bool:
+    r"""Render button for refreshing the selectable users.
+
+    Parameters
+    ----------
+    db_session : streamlit_passwordless.db.Session
+        An active session to the Streamlit Passwordless database.
+
+    label : str, default 'Refresh Users'
+        The label of the button.
+
+    disabled : bool, default False
+        If True the component is disabled from user interaction.
+
+    key : str, default streamlit_passwordless.app.keys.ADMIN_REFRESH_USERS_BUTTON
+        The unique identifier of the component. Each component on a page must have a unique key.
+
+    Returns
+    -------
+    bool
+        True if the button was clicked and False otherwise.
+    """
+
+    return st.button(
+        label=label,
+        disabled=disabled,
+        key=key,
+        help='Load users from the database.',
+        on_click=get_selectable_users_from_database,  # type: ignore
+        kwargs={'db_session': db_session},
+    )
+
+
+def delete_user_button(
+    client: BitwardenPasswordlessClient,
+    db_session: db.Session,
+    label: str = 'Delete User',
+    disabled: bool = False,
+    key=keys.ADMIN_DELETE_USER_BUTTON,
+) -> bool:
+    r"""Render the button for deleting a user.
+
+    Parameters
+    ----------
+    client : streamlit_passwordless.BitwardenPasswordlessClient
+        An instance of the Bitwarden Passwordless client to
+        communicate with the backend API.
+
+    db_session : streamlit_passwordless.db.Session
+        An active session to the Streamlit Passwordless database.
+
+    label : str, default 'Delete User'
+        The label of the button.
+
+    disabled : bool, default False
+        If True the component is disabled from user interaction.
+
+    key : str, default streamlit_passwordless.app.keys.ADMIN_DELETE_USER_BUTTON
+        The unique identifier of the component. Each component on a page must have a unique key.
+
+    Returns
+    -------
+    bool
+        True if the button was clicked and False otherwise.
+    """
+
+    return st.button(
+        label=label,
+        key=key,
+        disabled=disabled,
+        help='Delete a user from the database and Bitwarden Passwordless.dev.',
+    )
+
+
+def user_role_multiselect(
+    roles: Sequence[db.models.Role],
+    label: str = 'Roles',
+    placeholder: str = 'Select the roles to filter by',
+    key=keys.ADMIN_USER_ROLE_MULTISELECT,
+) -> list[db.models.Role]:
+    r"""Render the multi-selectbox of the roles to use for filtering the selectable users.
+
+    Parameters
+    ----------
+    roles : Sequence[streamlit_passwordless.db.models.Role]
+        The selectable roles.
+
+    label : str, default 'Roles'
+        The label of the multi-selectbox.
+
+    placeholder : str, default 'Select the roles to filter by'
+        The placeholder to display if no role is chosen.
+
+    key : str, default streamlit_passwordless.app.keys.ADMIN_USER_ROLE_MULTISELECT
+        The unique identifier of the component. Each component on a page must have a unique key.
+
+    Returns
+    -------
+    list[streamlit_passwordless.db.models.Role]
+        The selected roles.
+    """
+
+    return st.multiselect(
+        label=label,
+        options=roles,
+        format_func=lambda r: r.name,
+        key=key,
+        placeholder=placeholder,
+        help='Filter the users by roles.',
+    )
+
+
+def user_selectbox(
+    df: pd.DataFrame, preselected_user: int | None = None, placeholder: str = 'Choose a user'
+) -> str:
+    r"""Render the selectbox for selecting the user to process.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        The DataFrame with the user info to provide for selecting a user. The index column
+        should contain the user_id:s of the users. The columns of the DataFrame should be the
+        searchable columns "username, "displayname", and "ad_username".
+
+    preselected_user : int or None, default None
+        The pre-selected user on first render of the component. 0 means the first user of `df`.
+        If None no user is pre-selected and the value of `placeholder` is displayed instead.
+
+    placeholder : str, default 'Choose a user'
+        The placeholder to display if no user is chosen.
+
+    key : str, default streamlit_passwordless.app.keys.ADMIN_USER_SELECTBOX
+        The unique identifier of the component. Each component on a page must have a unique key.
+
+    Returns
+    -------
+    str
+        The selected user.
+    """
+
+    def format_user_display_text(user_id: str) -> str:
+        r"""The text to display instead of the user_id in the selectbox."""
+
+        s = df.loc[user_id, ['username', 'displayname', 'ad_username']]  # type: ignore
+
+        return f'{s["username"]} | {s["displayname"]} | {s["ad_username"]}'
+
+    nr_users = df.shape[0]
+    label = (
+        f'Select from {nr_users} user{"s" if nr_users > 0 else ""} '
+        '(username | displayname | ad_username)'
+    )
+    return st.selectbox(
+        label=label,
+        options=df.index,
+        index=preselected_user,  # type: ignore
+        format_func=format_user_display_text,
+        key=keys.ADMIN_USER_SELECTBOX,
+        placeholder=placeholder,
+        help='Search for a user by username, displayname or ad_username',
+    )

--- a/src/streamlit_passwordless/app/components/keys.py
+++ b/src/streamlit_passwordless/app/components/keys.py
@@ -1,0 +1,12 @@
+r"""The ID:s (keys) of components used for identification and session state management."""
+
+# =====================================================================================
+# Admin
+# =====================================================================================
+
+ADMIN_USER_ROLE_MULTISELECT = 'stp-admin-user-role-multiselect'
+ADMIN_USER_STATE_RADIO_BUTTON = 'stp-admin-user-state-radio-button'
+ADMIN_USER_SELECTBOX = 'stp-admin-user-selectbox'
+ADMIN_CREATE_USER_BUTTON = 'stp-admin-create-user-button'
+ADMIN_DELETE_USER_BUTTON = 'stp-admin-delete-user-button'
+ADMIN_REFRESH_USERS_BUTTON = 'stp-admin-refresh-users-button'

--- a/src/streamlit_passwordless/app/controllers/admin.py
+++ b/src/streamlit_passwordless/app/controllers/admin.py
@@ -1,10 +1,13 @@
 r"""The controller of the admin page."""
 
+# Third party
+import streamlit as st
+
 # Local
 import streamlit_passwordless.database as db
-from streamlit_passwordless.app.views.admin import sidebar, title
+from streamlit_passwordless.app.logic.admin import load_users_and_roles_from_database
+from streamlit_passwordless.app.views.admin import manage_users_view, sidebar, title
 from streamlit_passwordless.bitwarden_passwordless import BitwardenPasswordlessClient
-from streamlit_passwordless.components import create_user_form
 from streamlit_passwordless.models import User
 
 
@@ -26,4 +29,13 @@ def controller(client: BitwardenPasswordlessClient, db_session: db.Session, user
 
     title()
     sidebar(user=user)
-    create_user_form(db_session=db_session, with_ad_username=True)
+    users_tab, roles_tab, custom_roles_tab = st.tabs(('Users', 'Roles', 'Custom Roles'))
+
+    df_users, roles, custom_roles = load_users_and_roles_from_database(db_session=db_session)
+
+    with users_tab:
+        manage_users_view(df=df_users, roles=roles, client=client, db_session=db_session)
+    with roles_tab:
+        pass
+    with custom_roles_tab:
+        pass

--- a/src/streamlit_passwordless/app/logic/__init__.py
+++ b/src/streamlit_passwordless/app/logic/__init__.py
@@ -1,0 +1,1 @@
+r"""The application logic of the Streamlit Passwordless web apps."""

--- a/src/streamlit_passwordless/app/logic/admin.py
+++ b/src/streamlit_passwordless/app/logic/admin.py
@@ -1,0 +1,162 @@
+r"""The application logic of the admin app."""
+
+# Standard library
+from typing import Sequence
+
+# Third party
+import pandas as pd
+import streamlit as st
+
+# Local
+import streamlit_passwordless.database as db
+from streamlit_passwordless.app.session_state import (
+    SK_DB_CUSTOM_ROLES,
+    SK_DB_ROLES,
+    SK_SELECTABLE_USERS_DATAFRAME,
+)
+
+
+def get_selectable_users_from_database(db_session: db.Session) -> pd.DataFrame:
+    r"""Load the selectable users from the database.
+
+    Updates the session state key
+    :attr:`streamlit_passwordless.app.components.keys.SK_SELECTABLE_USERS_DATAFRAME`
+    with the function result.
+
+    Parameters
+    ----------
+    db_session : streamlit_passwordless.db.Session
+        An active session to the Streamlit Passwordless database.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The selectable users.
+    """
+
+    df = db.get_all_users(session=db_session, as_df=True)
+    st.session_state[SK_SELECTABLE_USERS_DATAFRAME] = df
+
+    return df
+
+
+def get_all_roles_from_database(db_session: db.Session) -> Sequence[db.models.Role]:
+    r"""Load the user roles from the database.
+
+    Updates the session state key
+    :attr:`streamlit_passwordless.app.components.keys.SK_DB_ROLES`
+    with the function result.
+
+    Parameters
+    ----------
+    db_session : streamlit_passwordless.db.Session
+        An active session to the Streamlit Passwordless database.
+
+    Returns
+    -------
+    roles : Sequence[streamlit_passwordless.db.models.Role]
+        The user roles.
+    """
+
+    roles = db.get_all_roles(session=db_session, as_df=False)
+    st.session_state[SK_DB_ROLES] = roles
+
+    return roles
+
+
+def get_all_custom_roles_from_database(db_session: db.Session) -> Sequence[db.models.CustomRole]:
+    r"""Load the user custom roles from the database.
+
+    Updates the session state key
+    :attr:`streamlit_passwordless.app.components.keys.SK_DB_CUSTOM_ROLES`
+    with the function result.
+
+    Parameters
+    ----------
+    db_session : streamlit_passwordless.db.Session
+        An active session to the Streamlit Passwordless database.
+
+    Returns
+    -------
+    custom_roles : Sequence[streamlit_passwordless.db.models.Role]
+        The user custom roles.
+    """
+
+    custom_roles = db.get_all_custom_roles(session=db_session, as_df=False)
+    st.session_state[SK_DB_CUSTOM_ROLES] = custom_roles
+
+    return custom_roles
+
+
+def load_users_and_roles_from_database(
+    db_session: db.Session,
+) -> tuple[pd.DataFrame, Sequence[db.models.Role], Sequence[db.models.CustomRole]]:
+    r"""Load the selectable users, roles and custom roles from the database.
+
+    Parameters
+    ----------
+    db_session : streamlit_passwordless.db.Session
+        An active session to the Streamlit Passwordless database.
+
+    Returns
+    -------
+    df_users : pandas.DataFrame
+        The selectable users.
+
+    roles : Sequence[streamlit_passwordless.db.models.Role]
+        The user roles.
+
+    custom_roles : Sequence[streamlit_passwordless.db.models.CustomRole]
+        The user custom roles.
+    """
+
+    if st.session_state.get(SK_SELECTABLE_USERS_DATAFRAME) is None:
+        get_selectable_users_from_database(db_session=db_session)
+    df_users = st.session_state.get(SK_SELECTABLE_USERS_DATAFRAME, pd.DataFrame())
+
+    if st.session_state.get(SK_DB_ROLES) is None:
+        get_all_roles_from_database(db_session=db_session)
+    roles = st.session_state.get(SK_DB_ROLES, [])
+
+    if st.session_state.get(SK_DB_CUSTOM_ROLES) is None:
+        get_all_custom_roles_from_database(db_session=db_session)
+    custom_roles = st.session_state.get(SK_DB_CUSTOM_ROLES, [])
+
+    return df_users, roles, custom_roles
+
+
+def filter_selectable_users(
+    df: pd.DataFrame, disabled: bool | None, roles: set[int]
+) -> pd.DataFrame:
+    r"""Filter the selectable users.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        The selectable users.
+
+    disabled : bool or None
+        Filter by disabled (True) or enabled (False) users.
+        If None filtering by disabled/enabled is omitted.
+
+    roles : set[int]
+        The role_id:s of the user roles to filter by.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The selectable users after filtering by disabled/enabled and roles.
+    """
+
+    if disabled is None:
+        if roles:
+            return df.loc[df['role_id'].isin(roles), :]
+        else:
+            return df
+    else:
+        disabled_filter = df['disabled'].eq(disabled)
+        if roles:
+            roles_filter = df['role_id'].isin(roles)
+            return df.loc[disabled_filter & roles_filter, :]
+        else:
+            return df.loc[disabled_filter, :]

--- a/src/streamlit_passwordless/app/session_state.py
+++ b/src/streamlit_passwordless/app/session_state.py
@@ -1,0 +1,9 @@
+r"""Functionality for managing the session state of the web apps."""
+
+# =====================================================================================
+# Session state keys
+# =====================================================================================
+
+SK_DB_ROLES = 'stp-db-roles'
+SK_DB_CUSTOM_ROLES = 'stp-db-custom-roles'
+SK_SELECTABLE_USERS_DATAFRAME = 'stp-selectable-users-dataframe'

--- a/src/streamlit_passwordless/app/views/admin.py
+++ b/src/streamlit_passwordless/app/views/admin.py
@@ -39,3 +39,29 @@ def sidebar(user: User) -> None:
     with st.sidebar:
         sign_out_button(user=user)
         st.markdown(user_info)
+
+
+def statistics_view(nr_users_database: int, nr_users_bwp: int, nr_passkeys: int) -> None:
+    r"""The statistics view of the admin page.
+
+    Display the number of users and the number of registered passkeys.
+
+    Parameters
+    ----------
+    nr_users_database : int
+        The number of users in the database.
+
+    nr_users_bwp : int
+        The number of registered users in Bitwarden Passwordless.dev.
+
+    nr_passkeys : int
+        The number of registered passkeys in Bitwarden Passwordless.dev.
+    """
+
+    nr_local_users_col, nr_bwp_users_col, nr_passkeys_col = st.columns([0.3, 0.4, 0.3])
+    with nr_local_users_col:
+        st.metric(label='Users in Database', value=nr_users_database)
+    with nr_bwp_users_col:
+        st.metric(label='Users Bitwarden Passwordless', value=nr_users_bwp)
+    with nr_passkeys_col:
+        st.metric(label='Registered Passkeys', value=nr_passkeys)

--- a/src/streamlit_passwordless/app/views/admin.py
+++ b/src/streamlit_passwordless/app/views/admin.py
@@ -1,9 +1,29 @@
 r"""The views of the admin page."""
 
+# Standard library
+from typing import Sequence
+
 # Third party
+import pandas as pd
 import streamlit as st
 
 # Local
+import streamlit_passwordless.database as db
+from streamlit_passwordless.app.components.admin import (
+    create_user_button,
+    delete_user_button,
+    refresh_users_button,
+    user_role_multiselect,
+    user_selectbox,
+    user_state_radio_button,
+)
+from streamlit_passwordless.app.logic.admin import filter_selectable_users
+from streamlit_passwordless.bitwarden_passwordless import BitwardenPasswordlessClient
+from streamlit_passwordless.components import (
+    BannerMessageType,
+    bitwarden_register_form_existing_user,
+    display_banner_message,
+)
 from streamlit_passwordless.components.sign_out import sign_out_button
 from streamlit_passwordless.models import User
 
@@ -65,3 +85,106 @@ def statistics_view(nr_users_database: int, nr_users_bwp: int, nr_passkeys: int)
         st.metric(label='Users Bitwarden Passwordless', value=nr_users_bwp)
     with nr_passkeys_col:
         st.metric(label='Registered Passkeys', value=nr_passkeys)
+
+
+@st.fragment
+def manage_users_view(
+    df: pd.DataFrame,
+    roles: Sequence[db.models.Role],
+    client: BitwardenPasswordlessClient,
+    db_session: db.Session,
+) -> None:
+    r"""Manage the users of the application.
+
+    The view allows to create, update and delete users.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        The selectable users to manage.
+
+    roles: Sequence[streamlit_passwordless.db.models.Role]
+        The roles of the users to use for filtering the selectable users.
+
+    client : streamlit_passwordless.BitwardenPasswordlessClient
+        An instance of the Bitwarden Passwordless client to
+        communicate with the backend API.
+
+    db_session : streamlit_passwordless.db.Session
+        An active session to the Streamlit Passwordless database.
+    """
+
+    filter_col, space_col, button_col, statistics_col = st.columns(
+        [0.3, 0.1, 0.3, 0.3],
+        vertical_alignment='bottom',
+        gap='small',
+    )
+    with filter_col:
+        left_col, right_col = st.columns([0.4, 0.6])
+        with left_col:
+            selected_user_state = user_state_radio_button()
+        with right_col:
+            selected_roles = user_role_multiselect(roles=roles)
+
+    with space_col:
+        pass
+
+    with button_col:
+        left_col, right_col = st.columns(2)
+        with left_col:
+            refresh_users_button(db_session=db_session)
+        with right_col:
+            create_user_button(db_session=db_session)
+
+    with statistics_col:
+        statistics_view(nr_users_database=df.shape[0], nr_users_bwp=0, nr_passkeys=0)
+
+    if df.shape[0] > 0:
+        df = filter_selectable_users(
+            df=df, disabled=selected_user_state, roles={r.role_id for r in selected_roles}
+        )
+    selected_user_id = user_selectbox(df=df)
+
+    st.divider()  # User and email
+
+    if selected_user_id:
+        db_user = db.get_user_by_user_id(session=db_session, user_id=selected_user_id)
+    else:
+        db_user = None
+
+    left_col, right_col = st.columns([0.5, 0.5], vertical_alignment='top')
+    with left_col:
+        title_col, delete_button_col = st.columns([0.7, 0.3], vertical_alignment='bottom')
+        with title_col:
+            st.markdown('### Update User')
+        with delete_button_col:
+            delete_user_button(client=client, db_session=db_session, disabled=db_user is None)
+
+        if selected_user_id is None:
+            emails = []
+            display_banner_message(
+                message='Select a user to update!', message_type=BannerMessageType.INFO
+            )
+        elif db_user is None:
+            emails = []
+            display_banner_message(
+                message='Selected user not found in database!',
+                message_type=BannerMessageType.ERROR,
+            )
+        else:
+            st.write(db_user)
+            emails = db_user.emails
+
+    with right_col:
+        st.metric(label='Emails', value=len(emails))
+        st.write(emails)
+
+    st.divider()  # Passkeys
+
+    left_col, right_col = st.columns([0.5, 0.5], vertical_alignment='top')
+    with left_col:
+        bitwarden_register_form_existing_user(
+            client=client, db_session=db_session, user=st.session_state['stp-user']
+        )
+    with right_col:
+        st.metric(label='Passkeys', value=3)


### PR DESCRIPTION
Adding a new layout for the page with a search section, an update and email section and a passkey section.
The page is also divided into 3 tabs for managing users, roles and custom roles respectively.